### PR TITLE
server/csharp: Fix issues around `last_updated` field.

### DIFF
--- a/server/csharp/TicketHub/Controllers/TicketController.cs
+++ b/server/csharp/TicketHub/Controllers/TicketController.cs
@@ -89,7 +89,7 @@ public class TicketController : ControllerBase
 
         // Update ticket fields.
         ticket.Description = tf.description;
-        ticket.LastUpdated = DateTime.Now;
+        ticket.LastUpdated = DateTime.UtcNow.ToLocalTime();
         ticket.Tenant = foundTenant.Id;
         ticket.Customer = foundCustomer.Id;
 
@@ -111,7 +111,7 @@ public class TicketController : ControllerBase
             return NotFound();
         }
         ticket.Resolved = rf.resolved;
-        ticket.LastUpdated = DateTime.Now;
+        ticket.LastUpdated = DateTime.UtcNow.ToLocalTime();
         await _dbContext.SaveChangesAsync();
         return Ok(ticket);
     }

--- a/server/csharp/TicketHub/Database/Ticket.cs
+++ b/server/csharp/TicketHub/Database/Ticket.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.AspNetCore.Authentication;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 
 namespace TicketHub.Database;
@@ -13,6 +14,8 @@ public partial class Ticket
 
     public string? Description { get; set; }
 
+    [JsonProperty("last_updated")]
+    [JsonConverter(typeof(UtcDateTimeConverter))]
     public DateTime LastUpdated { get; set; }
 
     public bool Resolved { get; set; }
@@ -68,5 +71,14 @@ public class TicketConverter : JsonConverter
     public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
     {
         throw new NotImplementedException();
+    }
+}
+
+public class UtcDateTimeConverter : IsoDateTimeConverter
+{
+    public UtcDateTimeConverter()
+    {
+        DateTimeFormat = "yyyy-MM-ddTHH:mm:ssZ";
+        DateTimeStyles = System.Globalization.DateTimeStyles.AssumeUniversal;
     }
 }


### PR DESCRIPTION
## What changed?

This PR fixes an issue where the UI would not display timestamps, or appear to visibly update them during ticket resolve/unresolve UI interactions, when using the `csharp` server profile.

The cause was the C# server's EF Core model expecting (and serializing) the field as `lastUpdated` instead of `last_updated`. By adding a few model annotations + UTC conversion logic in the controller, things seem to be back in working order.

<details>
<summary><b>curl /tickets before fix</b></summary>

```bash
$ curl --header 'Content-Type: application/json' --cookie 'user=acmecorp / bob' 'http://localhost:4000/api/tickets'
{"tickets":[{"id":11,"description":"Gibberish gibberish","lastUpdated":"2024-04-30T21:26:35.816112","resolved":true,"customer":"Globex","tenant":"acmecorp"},{"id":2,"description":"Flamethrower implementation is too heavyweight","lastUpdated":"2024-04-30T21:26:34.249131","resolved":true,"customer":"Globex","tenant":"acmecorp"},{"id":1,"description":"Dooms day device needs to be refactored","lastUpdated":"2024-04-30T21:26:34.249131","resolved":false,"customer":"Globex","tenant":"acmecorp"},{"id":4,"description":"Happy Vertical People Transporters need to be more efficient in determining destination floor","lastUpdated":"2024-04-30T21:26:34.249131","resolved":false,"customer":"Sirius Cybernetics Corp.","tenant":"acmecorp"},{"id":3,"description":"Latest android exhibit depression tendencies","lastUpdated":"2024-04-30T21:26:34.249131","resolved":false,"customer":"Sirius Cybernetics Corp.","tenant":"acmecorp"},{"id":6,"description":"Temporal dislocation field reacts with exposed metal","lastUpdated":"2024-04-30T21:26:34.249131","resolved":true,"customer":"Cyberdyne Systems Corp.","tenant":"acmecorp"},{"id":5,"description":"Mimetic polyalloy becomes brittle at low temperatures","lastUpdated":"2024-04-30T21:26:34.249131","resolved":false,"customer":"Cyberdyne Systems Corp.","tenant":"acmecorp"}]}
```

</details>

<details>
<summary><b>curl /tickets after fix</b></summary>

```bash
$ curl --header 'Content-Type: application/json' --cookie 'user=acmecorp / bob' 'http://localhost:4000/api/tickets'
{"tickets":[{"id":1,"description":"Dooms day device needs to be refactored","last_updated":"2024-05-02T19:52:31Z","resolved":false,"customer":"Globex","tenant":"acmecorp"},{"id":2,"description":"Flamethrower implementation is too heavyweight","last_updated":"2024-05-02T19:52:01Z","resolved":true,"customer":"Globex","tenant":"acmecorp"},{"id":4,"description":"Happy Vertical People Transporters need to be more efficient in determining destination floor","last_updated":"2024-05-02T19:52:01Z","resolved":false,"customer":"Sirius Cybernetics Corp.","tenant":"acmecorp"},{"id":3,"description":"Latest android exhibit depression tendencies","last_updated":"2024-05-02T19:52:01Z","resolved":false,"customer":"Sirius Cybernetics Corp.","tenant":"acmecorp"},{"id":6,"description":"Temporal dislocation field reacts with exposed metal","last_updated":"2024-05-02T19:52:01Z","resolved":true,"customer":"Cyberdyne Systems Corp.","tenant":"acmecorp"},{"id":5,"description":"Mimetic polyalloy becomes brittle at low temperatures","last_updated":"2024-05-02T19:52:01Z","resolved":false,"customer":"Cyberdyne Systems Corp.","tenant":"acmecorp"}]}
```

</details>