### PR TITLE
ci: Add Dependabot config for updating the C# server.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+  - package-ecosystem: "nuget"
+    directory: "/server/csharp"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
   - package-ecosystem: "npm"
     directory: "/client/react"
     schedule:


### PR DESCRIPTION
## What Changed?

This PR updates our Dependabot config to auto-update NuGet dependencies for the C# server.

**Note**: I'm not certain that Dependabot will recurse correctly down to where the `.csproj` file is (`/server/csharp/TicketHub`), so there may be a follow-up PR after this one, depending on whether or not we start seeing version bump PRs in the next day or two.