### PR TITLE
client/react: copy packages/ in Dockerfile

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -51,14 +51,15 @@ jobs:
         with:
           fetch-depth: 0
       - uses: open-policy-agent/setup-opa@v2
-      - name: build bundle
-        run: make policies/bundle.tar.gz
+      - name: build wasm bundle
+        run: make client/react/public/opa.wasm
         env:
           OPA: opa
+        if: ${{ matrix.client == 'react' }}
       - name: setup
-        run: docker compose --profile ${{ matrix.client }} up --quiet-pull --wait --wait-timeout 300
+        run: docker compose --profile ${{ matrix.client }} up --quiet-pull --wait --wait-timeout 300 --build
       - name: smoke test
-        run: curl --retry 5 --retry-connrefused --retry-max-time 120 http://127.0.0.1:3000
+        run: curl --retry 5 --retry-connrefused --retry-max-time 120 http://127.0.0.1:3000 -v
 
   test-e2e:
     name: Test E2E

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ The TicketHub sample application to show off using the Styra OPA SDKs:
 
 ## Build the OPA Bundle
 
-On the first checkout, or whenever something in `policies/` is changed, the OPA bundle needs to be rebuild:
+On the first checkout, or whenever something in `policies/` is changed, the OPA Wasm bundle needs to be rebuild for use in `client/react`:
 ```sh
-make policies/bundle.tar.gz
+make client/react/public/opa.wasm
 ```
 
 ## Running the Tickethub app
@@ -39,6 +39,6 @@ docker compose --profile node --profile react up
 Then open the browser at `http://localhost:3000`
 
 > [!WARNING]
-> Using docker compose requires `networking_mode: host`. 
+> Using docker compose requires `networking_mode: host`.
 > This is disabled by default on MacOS and Windows for Docker Desktop.
 > See the [Docker Desktop documentation](https://docs.docker.com/network/drivers/host/) for information on how to enable this mode.

--- a/client/react/Dockerfile
+++ b/client/react/Dockerfile
@@ -5,6 +5,7 @@ COPY package.json package-lock.json ./
 RUN npm install
 COPY src src
 COPY public public
+COPY packages packages
 EXPOSE 3000
 ENV SERVER_HOST "0.0.0.0"
 CMD [ "npm", "start"]


### PR DESCRIPTION
1. Build wasm module in CI run for client/{html,react}.
2. mention new make call in top-level README. **Note**: I have not invested time in updating the docker container for that... we'd need to use the OPA from the OPA container to build something that's used in the client/react container... But we can revisit if we feel strongly about this.