### PR TITLE
client/react: use prod build + caddy

### DIFF
--- a/client/react/Dockerfile
+++ b/client/react/Dockerfile
@@ -1,14 +1,17 @@
-FROM node:21-alpine
+FROM node:21-alpine AS builder
 RUN mkdir -p /opt/app
 WORKDIR /opt/app
 COPY package.json package-lock.json ./
 COPY packages packages
 RUN cd packages/opa-wasm && npm ci && npx tsc
 RUN cd packages/opa-react && npm ci && npx tsc
-RUN npm install
+RUN npm ci
 RUN cd packages/opa-react && npm link ../../node_modules/react
 COPY src src
 COPY public public
+RUN npm run build
+
+FROM caddy:latest
 EXPOSE 3000
-ENV SERVER_HOST "0.0.0.0"
-CMD [ "npm", "start"]
+COPY --from=builder /opt/app/build /usr/share/caddy/
+COPY caddy/Caddyfile /etc/caddy/Caddyfile

--- a/client/react/caddy/Caddyfile
+++ b/client/react/caddy/Caddyfile
@@ -1,0 +1,27 @@
+{
+    debug
+}
+:3000 {
+
+    # proxy API requests to the backend service,
+    # which takes care of checking the authorization header
+    handle /api/* {
+        reverse_proxy http://localhost:4000
+    }
+
+    # proxy OPA requests to OPA, if there's an authorization header
+    # NOTE: if header-based authentication was realistic, we would do
+    # more here to check the token
+    handle_path /opa/* {
+        @unauthenticated header !Authorization
+        respond @unauthenticated 401
+        reverse_proxy http://localhost:8181
+    }
+
+    # serve the react app
+    handle {
+      root * /usr/share/caddy
+      try_files {path} /
+      file_server
+   }
+}


### PR DESCRIPTION
This is to workaround this problem:
```
> styra-tickethub-react@0.3.0 start
> react-scripts start

Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
 - options.allowedHosts[0] should be a non-empty string.
```

Relying on the dev server for our "normal deployment" is icky to begin with, so this changes it: we'll now build the react app into `build/`, and serve that, as it should be, from a stupid HTTP server.