### PR TITLE
client/react: use @styra/opa by default

### DIFF
--- a/client/react/.env
+++ b/client/react/.env
@@ -1,1 +1,1 @@
-REACT_APP_USE_WASM=/opa.wasm
+#REACT_APP_USE_WASM=/opa.wasm

--- a/client/react/README.md
+++ b/client/react/README.md
@@ -8,10 +8,19 @@ The TicketHub sample app client component.
 2. `make client/react/public/opa.wasm`
 2. `docker compose --profile node --profile react up proxy-react server-node`
 
-## How to run (Wasm)
+## How to run (HTTP)
 
 1. `make run`.
 2. The server opens a listener on `0.0.0.0:3000`. Turn a browser to `http://localhost:3000` to see it in action.
+
+All policy evaluations will then use the [`@styra/opa`](https://www.npmjs.com/package/@styra/opa) SDK instance, and make one backend
+call per eval, via [`@styra/opa-react`](https://www.npmjs.com/package/@styra/opa-react).
+
+## How to run (Wasm)
+
+1. Change `.env` to say `REACT_APP_USE_WASM=/opa.wasm` (uncomment it)
+2. `make run`.
+3. The server opens a listener on `0.0.0.0:3000`. Turn a browser to `http://localhost:3000` to see it in action.
 
 ### How does it work:
 
@@ -21,11 +30,3 @@ user's own data. The policy (wasm) doesn't need to change, it will just use a
 different data set.
 
 All policy evaluations will then use the WasmSDK instance.
-
-
-## How to run (HTTP)
-
-Same as above, **but** with an unset `REACT_APP_USE_WASM`, either by editing `client/react/.env` or by adjusting the make call: `REACT_APP_USE_WASM= make run`.
-
-All policy evaluations will then use the SDK instance, and make one backend
-call per eval.


### PR DESCRIPTION
This way, tickethub serves as a nice extra integration test. It would do that for opa-wasm, too, but since `@strya/opa` is a released, promoted packaged, we should test that first.