### PR TITLE
client/react: enable batching by env var, do it in tests, too

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -73,11 +73,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: open-policy-agent/setup-opa@v2
-      - name: build bundle
-        run: make client/react/public/opa.wasm
-        env:
-          OPA: opa
       - name: setup
         run: docker compose --profile ${{ matrix.server }} --profile react up --quiet-pull --wait --wait-timeout 300
       - name: Install dependencies
@@ -108,3 +103,42 @@ jobs:
         with:
           check_name: Results for server-${{ matrix.server }}
           report_paths: tests/api/report.xml
+
+  test-e2e-batch:
+    name: Test E2E Batching
+    runs-on: ubuntu-22.04
+    env:
+      eopa_license: ${{ secrets.EOPA_LICENSE_KEY }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+        if: env.eopa_license != ''
+      - name: setup
+        run: docker compose --profile node --profile react up --quiet-pull --wait --wait-timeout 300
+        env:
+          OPA_DOCKERFILE: enterprise-opa.Dockerfile
+          EOPA_LICENSE_KEY: ${{ secrets.EOPA_LICENSE_KEY }}
+        if: env.eopa_license != ''
+      - name: Install dependencies
+        run: npm ci
+        working-directory: tests/e2e
+        if: env.eopa_license != ''
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+        working-directory: tests/e2e
+        if: env.eopa_license != ''
+      - name: Run Playwright tests
+        run: npx playwright test
+        working-directory: tests/e2e
+        if: env.eopa_license != ''
+      - uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-batching-node
+          path: tests/e2e/playwright-report/
+          retention-days: 7
+        if: env.eopa_license != '' && always()
+      - name: dump logs
+        run: docker compose --profile node logs
+        if: failure()

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -143,4 +143,4 @@ jobs:
         if: env.eopa_license != '' && always()
       - name: dump logs
         run: docker compose --profile node logs
-        if: failure()
+        if: always()

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -132,6 +132,8 @@ jobs:
       - name: Run Playwright tests
         run: npx playwright test
         working-directory: tests/e2e
+        env:
+          BATCHING: true
         if: env.eopa_license != ''
       - uses: actions/upload-artifact@v4
         with:

--- a/client/react/src/components/App.jsx
+++ b/client/react/src/components/App.jsx
@@ -3,7 +3,6 @@ import { Outlet, useLocation } from "react-router-dom";
 import Nav from "./Nav";
 import { useAuthn } from "../AuthnContext";
 import { AuthzProvider } from "@styra/opa-react";
-import { WasmSDK } from "opa-wasm";
 import { OPAClient } from "@styra/opa";
 
 import { Types } from "../types";
@@ -20,6 +19,8 @@ const titles = {
   [Types.TICKET]: "Ticket",
   [Types.TICKETS]: "Tickets",
 };
+
+const batch = false;
 
 export default function App() {
   const { user, tenant } = useAuthn();
@@ -49,7 +50,7 @@ export default function App() {
       opaClient={opaClient}
       defaultPath="tickets"
       defaultInput={{ user, tenant }}
-      batch={false}
+      batch={batch}
     >
       <Nav type={type} />
       <Outlet />

--- a/client/react/src/components/App.jsx
+++ b/client/react/src/components/App.jsx
@@ -24,7 +24,7 @@ export default function App() {
   const location = useLocation();
   const [batch, setBatch] = useState(() => {
     const params = new URLSearchParams(location.search);
-    return params.get("batch") ?? false;
+    return params.get("batch") === "true";
   }, [location]);
   const { user, tenant } = useAuthn();
   const [opaClient] = useState(() => {

--- a/client/react/src/components/App.jsx
+++ b/client/react/src/components/App.jsx
@@ -20,9 +20,12 @@ const titles = {
   [Types.TICKETS]: "Tickets",
 };
 
-const batch = false;
-
 export default function App() {
+  const location = useLocation();
+  const [batch, setBatch] = useState(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get("batch") ?? false;
+  }, [location]);
   const { user, tenant } = useAuthn();
   const [opaClient] = useState(() => {
     const href = window.location.toString();
@@ -35,7 +38,6 @@ export default function App() {
       },
     });
   }, [user, tenant]);
-  const location = useLocation();
   const [, type] =
     Object.entries(paths).find(([path]) =>
       location.pathname.startsWith(path),
@@ -53,6 +55,7 @@ export default function App() {
       batch={batch}
     >
       <Nav type={type} />
+      <ToggleBatchingButton batch={batch} setBatch={setBatch} />
       <Outlet />
     </AuthzProvider>
   );
@@ -71,4 +74,19 @@ async function getUserData(user, tenant) {
   });
 
   return sdk.evaluate("userdata", { user, tenant });
+}
+
+function ToggleBatchingButton({ batch, setBatch }) {
+  const handleChange = () => {
+    setBatch(!batch);
+  };
+
+  return (
+    <button
+      onClick={handleChange}
+      className={`toggle-batching-button ${batch ? "on" : "off"}`}
+    >
+      {batch ? "batching enabled" : "batching disabled"}
+    </button>
+  );
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -116,7 +116,7 @@ services:
     init: true
     build:
       context: .
-      dockerfile: opa.Dockerfile
+      dockerfile: ${OPA_DOCKERFILE-opa.Dockerfile}
     ports:
       - "8181:8181"
     command:
@@ -129,6 +129,8 @@ services:
     working_dir: /
     volumes:
       - ./policies:/policies
+    environment:
+      EOPA_LICENSE_KEY: ${EOPA_LICENSE_KEY}
 
   integration-tests:
     image: ghcr.io/orange-opensource/hurl:latest

--- a/enterprise-opa.Dockerfile
+++ b/enterprise-opa.Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:latest
+
+COPY --from=ghcr.io/styrainc/enterprise-opa:latest /ko-app/enterprise-opa-private /usr/bin/opa
+
+RUN echo "#!/bin/sh" > /entrypoint.sh && \
+    echo "opa build -o /bundle.tar.gz --bundle /policies"  >> /entrypoint.sh && \
+    echo 'opa "$@"' >> /entrypoint.sh && \
+    chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["run"]

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.44.1",
-        "@types/node": "^20.14.2"
+        "@types/node": "^20.14.10"
       }
     },
     "node_modules/@playwright/test": {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -9,6 +9,6 @@
   "license": "ISC",
   "devDependencies": {
     "@playwright/test": "^1.44.1",
-    "@types/node": "^20.14.2"
+    "@types/node": "^20.14.10"
   }
 }

--- a/tests/e2e/tests/tickets.spec.ts
+++ b/tests/e2e/tests/tickets.spec.ts
@@ -1,21 +1,23 @@
 import { test, expect } from "@playwright/test";
 
+const baseURL = `http://127.0.0.1:3000/?batch=${process.env.BATCHING == "true"}`;
+
 test("has title with tenant and list of tickets", async ({ page }) => {
-  await page.goto("http://127.0.0.1:3000/");
+  await page.goto(baseURL);
   await expect(page).toHaveTitle(/Tickets - acmecorp/);
 
   await expect(page.locator("#ticket-list > tbody > tr ")).toHaveCount(6);
 });
 
 test("alice (default user) can create new tickets", async ({ page }) => {
-  await page.goto("http://127.0.0.1:3000/");
+  await page.goto(baseURL);
   await expect(
     page.getByRole("button", { name: "+ New Ticket" }),
   ).toBeEnabled();
 });
 
 test("bob can not create new tickets", async ({ page }) => {
-  await page.goto("http://127.0.0.1:3000/");
+  await page.goto(baseURL);
   await page.getByLabel("User").selectOption("bob");
   await expect(
     page.getByRole("button", { name: "+ New Ticket" }),
@@ -25,7 +27,7 @@ test("bob can not create new tickets", async ({ page }) => {
 test("select another tenant's user switches title and ticket list", async ({
   page,
 }) => {
-  await page.goto("http://127.0.0.1:3000/");
+  await page.goto(baseURL);
   await page.getByLabel("User").selectOption("dylan");
   await expect(page).toHaveTitle(/Tickets - hooli/);
   await expect(page.locator("#ticket-list > tbody > tr ")).toHaveCount(4);


### PR DESCRIPTION
There is a new button 😅 It's slightly ugly but the best I could do 👇 
<img width="439" alt="image" src="https://github.com/user-attachments/assets/88909d11-6064-4130-b406-25fb993b46e8">

Its initial value is taken from `?batch=true`, so if you want to enable batch requests **from the start**, you'll go to http://localhost:3000/?batch=true. This is also what playwright does in the extra test suite.

Note that to have the backend ready, you'll need to start EOPA instead of OPA. This can be done by setting `OPA_DOCKERFILE=enterprise-opa.Dockerfile`, while having `EOPA_LICENSE_KEY` set to a license key.