### PR TITLE
server/csharp: Update to use logging + authz attribute.

### DIFF
--- a/server/csharp/TicketHub/Authorization/OpaAuthorizationAttribute.cs
+++ b/server/csharp/TicketHub/Authorization/OpaAuthorizationAttribute.cs
@@ -5,14 +5,65 @@ using Styra.Opa;
 
 namespace TicketHub.Authorization;
 
-// Custom authorization attribute, allowing us to template in the fields our
-// policy needs in the input.
-public class OpaAuthorizationAttribute : ActionFilterAttribute
+// Custom authorization attribute, implemented as an authorization filter.
+// This design allows us to template in the fields our policy needs
+// in the input.
+public class OpaRuleAuthorizationAttribute : Attribute, IAsyncAuthorizationFilter
 {
     private readonly string _path;
     private readonly string _action;
 
-    public OpaAuthorizationAttribute(string path, string action)
+    public OpaRuleAuthorizationAttribute(string path, string action)
+    {
+        _path = path;
+        _action = action;
+    }
+
+    public async Task OnAuthorizationAsync(AuthorizationFilterContext context)
+    {
+        bool authorized = await IsAuthorized(context);
+        if (!authorized)
+        {
+            // If not authorized, return an error response
+            context.Result = new ContentResult
+            {
+                Content = "Not Authorized",
+                StatusCode = 403,
+            };
+            return;
+        }
+
+        // If authorized, allow normal controller handling.
+        return;
+    }
+
+    private async Task<bool> IsAuthorized(AuthorizationFilterContext context)
+    {
+        var httpContext = context.HttpContext;
+        string tenant = httpContext.Items["Tenant"]?.ToString() ?? "";
+        string subject = httpContext.Items["Subject"]?.ToString() ?? "";
+        var authzService = context.HttpContext.RequestServices.GetRequiredService<OpaAuthzService>();
+        OpaClient opa = authzService.GetClient();
+
+        bool allowed = await opa.evaluate<bool>(_path, new Dictionary<string, object>(){
+            { "tenant", tenant },
+            { "user", subject },
+            { "action", _action },
+        });
+        return allowed;
+    }
+}
+
+
+// Custom authorization attribute, implemented as an action filter.
+// This design allows us to template in the fields our policy needs
+// in the input.
+public class OpaRuleActionFilterAttribute : ActionFilterAttribute
+{
+    private readonly string _path;
+    private readonly string _action;
+
+    public OpaRuleActionFilterAttribute(string path, string action)
     {
         _path = path;
         _action = action;

--- a/server/csharp/TicketHub/Authorization/OpaAuthzService.cs
+++ b/server/csharp/TicketHub/Authorization/OpaAuthzService.cs
@@ -6,10 +6,11 @@ namespace TicketHub.Authorization;
 public class OpaAuthzService
 {
     private readonly OpaClient opa;
-    public OpaAuthzService()
+    public OpaAuthzService(ILogger<OpaClient> logger)
     {
         string opaUrl = Environment.GetEnvironmentVariable("OPA_URL") ?? "http://localhost:8181";
-        opa = new OpaClient(opaUrl);
+        opa = new OpaClient(opaUrl, logger);
+        logger.LogInformation("OPA Client initialized");
     }
 
     public OpaClient GetClient()

--- a/server/csharp/TicketHub/Controllers/TicketController.cs
+++ b/server/csharp/TicketHub/Controllers/TicketController.cs
@@ -1,16 +1,8 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Styra.Opa;
 using System.Net.Mime;
-using System.ComponentModel.DataAnnotations.Schema;
-using System.Collections.Generic;
 using TicketHub.Authorization;
 using TicketHub.Database;
-using Newtonsoft.Json;
-using Microsoft.AspNetCore.Http.HttpResults;
-using Microsoft.AspNetCore.Diagnostics;
-using System.Diagnostics.Eventing.Reader;
-using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace TicketHub.Controllers;
 
@@ -44,7 +36,7 @@ public class TicketController : ControllerBase
     // List all tickets.
     [HttpGet]
     [Route("tickets")]
-    [OpaAuthorization("tickets/allow", "list")]
+    [OpaRuleAuthorization("tickets/allow", "list")]
     public async Task<ActionResult<IAsyncEnumerable<Ticket>>> ListTickets()
     {
         var tName = HttpContext.Items["Tenant"]?.ToString();
@@ -64,7 +56,7 @@ public class TicketController : ControllerBase
     // Get a specific ticket.
     [HttpGet]
     [Route("tickets/{id:int}")]
-    [OpaAuthorization("tickets/allow", "get")]
+    [OpaRuleAuthorization("tickets/allow", "get")]
     public async Task<ActionResult<Ticket>> GetTicket(int id)
     {
         Ticket? ticket = await _dbContext.Tickets
@@ -77,7 +69,7 @@ public class TicketController : ControllerBase
     // Create a ticket.
     [HttpPost]
     [Route("tickets")]
-    [OpaAuthorization("tickets/allow", "create")]
+    [OpaRuleAuthorization("tickets/allow", "create")]
     public async Task<ActionResult<Ticket>> CreateTicket([FromBody] TicketFields tf)
     {
 
@@ -102,7 +94,7 @@ public class TicketController : ControllerBase
     // Resolve a ticket.
     [HttpPost]
     [Route("tickets/{id:int}/resolve")]
-    [OpaAuthorization("tickets/allow", "resolve")]
+    [OpaRuleAuthorization("tickets/allow", "resolve")]
     public async Task<ActionResult<Ticket>> ResolveTicket(int id, [FromBody] ResolveFields rf)
     {
         Ticket? ticket = await _dbContext.Tickets.FindAsync(id);

--- a/server/csharp/TicketHub/Program.cs
+++ b/server/csharp/TicketHub/Program.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Diagnostics;
 using Newtonsoft.Json;
 using TicketHub.Authorization;
-using TicketHub.Controllers;
 using TicketHub.Database;
 
 var builder = WebApplication.CreateBuilder(args);


### PR DESCRIPTION
This commit includes 2x changes:

 - We now properly tie in the `OpaClient`'s logging into the ASP.NET logging system. (Via dependency injection.)
 - We now implement the authz controls on the endpoints with an `AuthorizationFilter` attribute. This is a slightly better fit overall, and allows rejecting bad requests earlier in the controller filter path.

The original implementation was an `ActionFilterAttribute`, which was more powerful than we needed, and runs later in the authorization process.

The original ActionFilterAttribute implementation has been left in, to serve as a basic reference. I'm open to either leaving it alone, or removing it entirely.

## Resources

 - https://learn.microsoft.com/en-us/aspnet/mvc/overview/older-versions-1/controllers-and-routing/understanding-action-filters-cs#the-different-types-of-filters