### PR TITLE
adopt Spring authN for TicketHub backend

### DIFF
--- a/server/springboot/src/main/java/com/styra/tickethub_springboot/dao/model/CustomAuthentication.java
+++ b/server/springboot/src/main/java/com/styra/tickethub_springboot/dao/model/CustomAuthentication.java
@@ -1,0 +1,66 @@
+package com.styra.tickethub_springboot.dao.model;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Map.entry;
+
+public class CustomAuthentication implements Authentication {
+
+    private final String tenantName;
+    private final String userName;
+    private boolean authenticated = true;
+
+    public CustomAuthentication(String tenantName, String userName) {
+        this.tenantName = tenantName;
+        this.userName = userName;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Object getCredentials() {
+        Map<String, Object> credentials = new HashMap<String, Object>();
+        return credentials;
+    }
+
+    @Override
+    public Object getDetails() {
+        Map<String, Object> details = new HashMap<String, Object>();
+        return details;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return userName;
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+        //return authenticated;
+        return true;
+    }
+
+    @Override
+    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+        this.authenticated = isAuthenticated;
+    }
+
+    @Override
+    public String getName() {
+        return userName;
+    }
+
+    public String getTenantName() {
+        return tenantName;
+    }
+}

--- a/server/springboot/src/main/java/com/styra/tickethub_springboot/dao/model/CustomAuthentication.java
+++ b/server/springboot/src/main/java/com/styra/tickethub_springboot/dao/model/CustomAuthentication.java
@@ -46,8 +46,7 @@ public class CustomAuthentication implements Authentication {
 
     @Override
     public boolean isAuthenticated() {
-        //return authenticated;
-        return true;
+        return authenticated;
     }
 
     @Override

--- a/server/springboot/src/main/java/com/styra/tickethub_springboot/dao/model/CustomAuthenticationFilter.java
+++ b/server/springboot/src/main/java/com/styra/tickethub_springboot/dao/model/CustomAuthenticationFilter.java
@@ -1,0 +1,40 @@
+package com.styra.tickethub_springboot.dao.model;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+// This custom authN filter implements the simplified authorization header
+// setup that the TicketHub demo uses.
+
+public class CustomAuthenticationFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        // NOTE: we can't just use the MDC versions of the header information,
+        // because this filter runs before the request header interceptor does.
+        // We could consider moving the MDC.put() calls here perhaps, or else
+        // just use the session authN information instead of MDC.
+
+        String authHeader = request.getHeader("Authorization");
+        var components = authHeader.split("\\s*[\\s+/]\\s*", 3);
+        if (components.length == 3) {
+            String tenantName = components[1].trim();
+            String userName = components[2].trim();
+
+            Authentication auth = new CustomAuthentication(tenantName, userName);
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}
+

--- a/server/springboot/src/main/java/com/styra/tickethub_springboot/dao/model/SecurityConfig.java
+++ b/server/springboot/src/main/java/com/styra/tickethub_springboot/dao/model/SecurityConfig.java
@@ -2,20 +2,21 @@ package com.styra.tickethub_springboot.dao.model;
 
 import java.util.Random;
 
-import org.springframework.context.annotation.Bean;
+import com.styra.opa.springboot.OPAAuthorizationManager;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.web.SecurityFilterChain;
-import org.slf4j.MDC;
-import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
-import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestWrapper;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import com.styra.opa.springboot.OPAAuthorizationManager;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestWrapper;
 
 import com.styra.opa.OPAClient;
 
@@ -56,8 +57,9 @@ public class SecurityConfig {
         // purposes, it is disabled because it makes it easier to work with
         // locally. If you want to use any of this code for a production
         // service, it is important to re-enable CSRF protection.
-        http.authorizeHttpRequests(authorize -> authorize
-                .anyRequest().access(am)).csrf(csrf -> csrf.disable());
+        http.addFilterBefore(new CustomAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
+            .authorizeHttpRequests(authorize -> authorize.anyRequest().access(am))
+            .csrf(csrf -> csrf.disable());
 
         return http.build();
     }


### PR DESCRIPTION
I thought I pulled this in with my reason field support for the HTML client, but apparently it got lost during repo surgery. This PR pulls in those changes.

Basically, this adds a custom spring authN implementation which uses the TicketHub's custom authz header format, meaning Spring will now think TicketHub users are really Authenticated. This has some nice properties on the Spring side, and should not impact the existing API functionality in any way.