### PR TITLE
server/aspnetcore: Add ASP.NET Core SDK server.

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        server: [node, csharp, java, springboot]
+        server: [node, csharp, aspnetcore, java, springboot]
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,14 @@ run-csharp-react: SERVER = csharp
 run-csharp-react: CLIENT = react
 run-csharp-react: run
 
+run-aspnetcore-html: SERVER = aspnetcore
+run-aspnetcore-html: CLIENT = html
+run-aspnetcore-html: run
+
+run-aspnetcore-react: SERVER = aspnetcore
+run-aspnetcore-react: CLIENT = react
+run-aspnetcore-react: run
+
 .PHONY: clean
 clean:
 	rm -rf dist
@@ -106,4 +114,12 @@ package-csharp-react: SERVER = csharp
 package-csharp-react: CLIENT = react
 package-csharp-react: tar-csharp-react
 
-package-all: package-node-html package-node-react package-java-html package-java-react package-csharp-html package-csharp-react package-go-html package-go-react
+package-aspnetcore-html: SERVER = aspnetcore
+package-aspnetcore-html: CLIENT = html
+package-aspnetcore-html: tar-aspnetcore-html
+
+package-aspnetcore-react: SERVER = aspnetcore
+package-aspnetcore-react: CLIENT = react
+package-aspnetcore-react: tar-aspnetcore-react
+
+package-all: package-node-html package-node-react package-java-html package-java-react package-csharp-html package-csharp-react package-aspnetcore-html package-aspnetcore-react  package-go-html package-go-react

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ docker compose --profile <SERVER_IMPLEMENTATION> --profile <CLIENT_IMPLEMENTATIO
 The list of `<SERVER_IMPLEMENTATION>` is:
 - `node`
 - `csharp`
+- `aspnetcore`
 - `java`
 - `springboot`
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,6 +28,20 @@ services:
     expose:
       - 4000
 
+  server-aspnetcore:
+    build: server/aspnetcore/
+    profiles:
+      - aspnetcore
+    environment:
+      OPA_URL: "http://localhost:8181"
+      DATABASE_CONN_STR: "Host=localhost;Database=postgres;Username=postgres;Password=schmickethub"
+    depends_on:
+      - database
+      - opa
+    network_mode: host
+    expose:
+      - 4000
+
   database:
     image: postgres
     restart: always

--- a/policies/aspnetcore.rego
+++ b/policies/aspnetcore.rego
@@ -1,0 +1,58 @@
+package tickets.aspnetcore
+
+default main = {"decision": false}
+
+authHeader := input.action.headers.authorization
+tenant := trim(split(split(authHeader, "/")[0], " ")[1], " \t")
+user := trim(split(authHeader, "/")[1], " \t")
+
+action = a {
+    input.action.name == "GET"
+    input.resource.id == "/tickets"
+    a := "list"
+} else = a {
+    input.action.name == "GET"
+    regex.match("^/tickets/[0-9]+$", input.resource.id)
+    a := "get"
+} else = a {
+    input.action.name == "POST"
+    input.resource.id == "/tickets"
+    a := "create"
+} else = a {
+    input.action.name == "PUT"
+    regex.match("^/tickets/[0-9]+$", input.resource.id)
+    a := "overwrite"
+} else = a {
+    input.action.name == "POST"
+    regex.match("^/tickets/[0-9]+/resolve$", input.resource.id)
+    a := "resolve"
+}
+
+xform := {
+    "user": user,
+    "tenant": tenant,
+    "action": action,
+}
+
+main = x {
+    d := data.tickets.allow with input as xform
+    reason_user := data.tickets.reason_user with input as xform
+    reason_admin := data.tickets.reason_admin with input as xform
+    x := {
+        "decision": d,
+        "context": {
+            "id": "0",
+            "reason_user": {
+                "en": reason_user
+            },
+            "reason_admin": {
+                "en": reason_admin
+            },
+            "data": {
+                "echo": input,
+                "tenant": tenant,
+                "user": user,
+            }
+        }
+    }
+}

--- a/policies/aspnetcore.rego
+++ b/policies/aspnetcore.rego
@@ -1,58 +1,58 @@
 package tickets.aspnetcore
 
-default main = {"decision": false}
+import rego.v1
 
-authHeader := input.action.headers.authorization
-tenant := trim(split(split(authHeader, "/")[0], " ")[1], " \t")
-user := trim(split(authHeader, "/")[1], " \t")
+default main := {"decision": false}
 
-action = a {
-    input.action.name == "GET"
-    input.resource.id == "/tickets"
-    a := "list"
-} else = a {
-    input.action.name == "GET"
-    regex.match("^/tickets/[0-9]+$", input.resource.id)
-    a := "get"
-} else = a {
-    input.action.name == "POST"
-    input.resource.id == "/tickets"
-    a := "create"
-} else = a {
-    input.action.name == "PUT"
-    regex.match("^/tickets/[0-9]+$", input.resource.id)
-    a := "overwrite"
-} else = a {
-    input.action.name == "POST"
-    regex.match("^/tickets/[0-9]+/resolve$", input.resource.id)
-    a := "resolve"
+auth_header := input.action.headers.Authorization
+
+tenant := trim(split(split(auth_header, "/")[0], " ")[1], " \t")
+
+user := trim(split(auth_header, "/")[1], " \t")
+
+action := a if {
+	input.action.name == "GET"
+	input.resource.id == "/api/tickets"
+	a := "list"
+} else := a if {
+	input.action.name == "GET"
+	regex.match(`^/api/tickets/[0-9]+$`, input.resource.id)
+	a := "get"
+} else := a if {
+	input.action.name == "POST"
+	input.resource.id == "/api/tickets"
+	a := "create"
+} else := a if {
+	input.action.name == "PUT"
+	regex.match(`^/api/tickets/[0-9]+$`, input.resource.id)
+	a := "overwrite"
+} else := a if {
+	input.action.name == "POST"
+	regex.match(`^/api/tickets/[0-9]+/resolve$`, input.resource.id)
+	a := "resolve"
 }
 
 xform := {
-    "user": user,
-    "tenant": tenant,
-    "action": action,
+	"user": user,
+	"tenant": tenant,
+	"action": action,
 }
 
-main = x {
-    d := data.tickets.allow with input as xform
-    reason_user := data.tickets.reason_user with input as xform
-    reason_admin := data.tickets.reason_admin with input as xform
-    x := {
-        "decision": d,
-        "context": {
-            "id": "0",
-            "reason_user": {
-                "en": reason_user
-            },
-            "reason_admin": {
-                "en": reason_admin
-            },
-            "data": {
-                "echo": input,
-                "tenant": tenant,
-                "user": user,
-            }
-        }
-    }
+main := x if {
+	d := data.tickets.allow with input as xform
+	reason_user := data.tickets.reason_user with input as xform
+	reason_admin := data.tickets.reason_admin with input as xform
+	x := {
+		"decision": d,
+		"context": {
+			"id": "0",
+			"reason_user": {"en": reason_user},
+			"reason_admin": {"en": reason_admin},
+			"data": {
+				"echo": input,
+				"tenant": tenant,
+				"user": user,
+			},
+		},
+	}
 }

--- a/server/aspnetcore/.dockerignore
+++ b/server/aspnetcore/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/server/aspnetcore/.gitignore
+++ b/server/aspnetcore/.gitignore
@@ -1,0 +1,6 @@
+obj/
+bin/
+debug/
+_site/
+/.vscode/
+.DS_Store

--- a/server/aspnetcore/Dockerfile
+++ b/server/aspnetcore/Dockerfile
@@ -1,0 +1,16 @@
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+WORKDIR /TicketHub
+
+# Copy everything
+COPY . ./
+# Restore as distinct layers
+RUN dotnet build
+# Build and publish a release
+RUN dotnet publish -c Release -o out
+
+# Build runtime image
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:8.0
+WORKDIR /TicketHub
+COPY --from=build-env /TicketHub/out .
+ENTRYPOINT ["dotnet", "TicketHub.dll", "--urls", "http://0.0.0.0:4000", "--logger", "console;verbosity=detailed"]
+

--- a/server/aspnetcore/LICENSE
+++ b/server/aspnetcore/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/server/aspnetcore/Makefile
+++ b/server/aspnetcore/Makefile
@@ -1,0 +1,8 @@
+compile:
+	dotnet build
+
+run: compile
+	cd TicketHub && dotnet run Tickethub.dll --urls "http://0.0.0.0:4000" --logger "console;verbosity=detailed"
+
+clean:
+	dotnet clean

--- a/server/aspnetcore/README.md
+++ b/server/aspnetcore/README.md
@@ -1,0 +1,17 @@
+# TicketHub C# Server
+
+The TicketHub sample app server component.
+
+## How to run
+
+1. `make run`.
+2. The server opens a listener on `0.0.0.0:4000`.
+
+## Notes
+
+This project was initially created with `dotnet new webapi -controllers --no-https --no-openapi --name TicketHub`, and modified from there.
+
+## SDKs
+
+* [SDK Documentation](https://docs.styra.com/sdk)
+* [OPA C# SDK](https://github.com/StyraInc/opa-csharp)

--- a/server/aspnetcore/TicketHub.sln
+++ b/server/aspnetcore/TicketHub.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TicketHub", "TicketHub\TicketHub.csproj", "{F2894F51-9800-4B7C-B065-12006558C431}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F2894F51-9800-4B7C-B065-12006558C431}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F2894F51-9800-4B7C-B065-12006558C431}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F2894F51-9800-4B7C-B065-12006558C431}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F2894F51-9800-4B7C-B065-12006558C431}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/server/aspnetcore/TicketHub/Controllers/TicketController.cs
+++ b/server/aspnetcore/TicketHub/Controllers/TicketController.cs
@@ -1,0 +1,110 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Net.Mime;
+using TicketHub.Database;
+
+namespace TicketHub.Controllers;
+
+[ApiController]
+[Route("/api")]
+[Produces("application/json")]
+[Consumes(MediaTypeNames.Application.Json)]
+public class TicketController : ControllerBase
+{
+    private readonly ILogger<TicketController> _logger;
+    private readonly PostgresContext _dbContext;
+
+    public record TicketFields(string customer, string description);
+    public record ResolveFields(bool resolved);
+
+    private async Task<Customer> addCustomer(Tenant tenant, string name)
+    {
+        Customer c = new Customer();
+        c.Name = name;
+        c.Tenant = tenant.Id;
+        await _dbContext.Customers.AddAsync(c);
+        return c;
+    }
+
+    public TicketController(ILogger<TicketController> logger, PostgresContext dbContext)
+    {
+        _logger = logger;
+        _dbContext = dbContext;
+    }
+
+    // List all tickets.
+    [HttpGet]
+    [Route("tickets")]
+    public async Task<ActionResult<IAsyncEnumerable<Ticket>>> ListTickets()
+    {
+        var tName = HttpContext.Items["Tenant"]?.ToString();
+        if (tName is string)
+        {
+            Tenant tenant = await getTenantByName(tName);
+            List<Ticket> tickets = await _dbContext.Tickets
+                .Include(t => t.CustomerNavigation)
+                .Include(t => t.TenantNavigation)
+                .Where(t => t.Tenant == tenant.Id)
+                .ToListAsync();
+            return Ok(new { Tickets = tickets });
+        }
+        return StatusCode(500, "No tickets found");
+    }
+
+    // Get a specific ticket.
+    [HttpGet]
+    [Route("tickets/{id:int}")]
+    public async Task<ActionResult<Ticket>> GetTicket(int id)
+    {
+        Ticket? ticket = await _dbContext.Tickets
+            .Include(t => t.CustomerNavigation)
+            .Include(t => t.TenantNavigation)
+            .FirstOrDefaultAsync(t => t.Id == id);
+        return Ok(ticket);
+    }
+
+    // Create a ticket.
+    [HttpPost]
+    [Route("tickets")]
+    public async Task<ActionResult<Ticket>> CreateTicket([FromBody] TicketFields tf)
+    {
+
+        string tenant = HttpContext.Items["Tenant"]?.ToString() ?? "";
+        Ticket ticket = new();
+        // Fetch tenant, then create customer if needed.
+        Tenant foundTenant = await _dbContext.Tenants.Where(t => t.Name == tenant).FirstAsync();
+        Customer foundCustomer = await _dbContext.Customers.Where(c => c.Name == tf.customer).FirstOrDefaultAsync() ?? await addCustomer(foundTenant, tf.customer);
+
+        // Update ticket fields.
+        ticket.Description = tf.description;
+        ticket.LastUpdated = DateTime.UtcNow.ToLocalTime();
+        ticket.Tenant = foundTenant.Id;
+        ticket.Customer = foundCustomer.Id;
+
+        // Add ticket to context, then propagate changes back to DB.
+        await _dbContext.Tickets.AddAsync(ticket);
+        await _dbContext.SaveChangesAsync();
+        return Ok(ticket);
+    }
+
+    // Resolve a ticket.
+    [HttpPost]
+    [Route("tickets/{id:int}/resolve")]
+    public async Task<ActionResult<Ticket>> ResolveTicket(int id, [FromBody] ResolveFields rf)
+    {
+        Ticket? ticket = await _dbContext.Tickets.FindAsync(id);
+        if (ticket is null)
+        {
+            return NotFound();
+        }
+        ticket.Resolved = rf.resolved;
+        ticket.LastUpdated = DateTime.UtcNow.ToLocalTime();
+        await _dbContext.SaveChangesAsync();
+        return Ok(ticket);
+    }
+
+    private async Task<Tenant> getTenantByName(string name)
+    {
+        return await _dbContext.Tenants.Where(tenant => tenant.Name == name).FirstAsync();
+    }
+}

--- a/server/aspnetcore/TicketHub/Controllers/TicketController.cs
+++ b/server/aspnetcore/TicketHub/Controllers/TicketController.cs
@@ -20,9 +20,11 @@ public class TicketController : ControllerBase
 
     private async Task<Customer> addCustomer(Tenant tenant, string name)
     {
-        Customer c = new Customer();
-        c.Name = name;
-        c.Tenant = tenant.Id;
+        Customer c = new()
+        {
+            Name = name,
+            Tenant = tenant.Id,
+        };
         await _dbContext.Customers.AddAsync(c);
         return c;
     }

--- a/server/aspnetcore/TicketHub/Controllers/TicketController.cs
+++ b/server/aspnetcore/TicketHub/Controllers/TicketController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System.Net.Mime;
+using System.Security.Claims;
 using TicketHub.Database;
 
 namespace TicketHub.Controllers;
@@ -37,7 +38,7 @@ public class TicketController : ControllerBase
     [Route("tickets")]
     public async Task<ActionResult<IAsyncEnumerable<Ticket>>> ListTickets()
     {
-        var tName = HttpContext.Items["Tenant"]?.ToString();
+        var tName = User.FindFirstValue("Tenant");
         if (tName is string)
         {
             Tenant tenant = await getTenantByName(tName);
@@ -68,8 +69,7 @@ public class TicketController : ControllerBase
     [Route("tickets")]
     public async Task<ActionResult<Ticket>> CreateTicket([FromBody] TicketFields tf)
     {
-
-        string tenant = HttpContext.Items["Tenant"]?.ToString() ?? "";
+        var tenant = User.FindFirstValue("Tenant");
         Ticket ticket = new();
         // Fetch tenant, then create customer if needed.
         Tenant foundTenant = await _dbContext.Tenants.Where(t => t.Name == tenant).FirstAsync();

--- a/server/aspnetcore/TicketHub/CookieMiddleware.cs
+++ b/server/aspnetcore/TicketHub/CookieMiddleware.cs
@@ -1,0 +1,54 @@
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+public class UseCookieAuthMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public UseCookieAuthMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task Invoke(HttpContext context)
+    {
+        // Note(philip): Because the cookie value we're using has invalid
+        // characters (spaces), we have to hack the cookie value out of the
+        // Cookie header ourselves. ASP.NET follows the RFC for cookie parsing,
+        // so it will reject the user cookie if we try to extract it with
+        // context.Request.Cookies["user"].
+        string? rawCookieHeader = context.Request.Headers["Cookie"];
+
+        // Cookie not found? Error out.
+        if (string.IsNullOrEmpty(rawCookieHeader))
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            await context.Response.WriteAsync("{\"error\": \"authentication error: user credentials not provided\"}");
+            return;
+        }
+
+        // Parse the cookie value.
+        string pattern = @"user=(?<tenant>[^/]+) / (?<subject>[^;]+)";
+        Match match = Regex.Match(rawCookieHeader, pattern);
+        if (match.Success)
+        {
+            // Extract the values using named capture groups
+            string tenant = match.Groups["tenant"].Value.Trim();
+            string subject = match.Groups["subject"].Value.Trim();
+            context.Items["Tenant"] = tenant;
+            context.Items["Subject"] = subject;
+        }
+
+        await _next(context);
+    }
+}
+
+public static class UseCookieAuthMiddlewareExtensions
+{
+    public static IApplicationBuilder UseCookieAuthMiddleware(this IApplicationBuilder builder)
+    {
+        return builder.UseMiddleware<UseCookieAuthMiddleware>();
+    }
+}

--- a/server/aspnetcore/TicketHub/Database/Customer.cs
+++ b/server/aspnetcore/TicketHub/Database/Customer.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace TicketHub.Database;
+
+public partial class Customer
+{
+    public int Id { get; set; }
+
+    public int Tenant { get; set; }
+
+    public string? Name { get; set; }
+
+    public virtual Tenant TenantNavigation { get; set; } = null!;
+
+    public virtual ICollection<Ticket> Tickets { get; set; } = new List<Ticket>();
+}

--- a/server/aspnetcore/TicketHub/Database/PostgresContext.cs
+++ b/server/aspnetcore/TicketHub/Database/PostgresContext.cs
@@ -1,0 +1,95 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace TicketHub.Database;
+
+public partial class PostgresContext : DbContext
+{
+    public PostgresContext()
+    {
+    }
+
+    public PostgresContext(DbContextOptions<PostgresContext> options)
+        : base(options)
+    {
+    }
+
+    public virtual DbSet<Customer> Customers { get; set; }
+
+    public virtual DbSet<Tenant> Tenants { get; set; }
+
+    public virtual DbSet<Ticket> Tickets { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        string pgConnString = Environment.GetEnvironmentVariable("DATABASE_CONN_STR") ?? "Host=localhost;Database=postgres;Username=postgres;Password=schmickethub";
+        optionsBuilder.UseNpgsql(pgConnString, npgsqlOptions => npgsqlOptions.UseNodaTime());
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Customer>(entity =>
+        {
+            entity.HasKey(e => e.Id).HasName("Customers_pkey");
+
+            entity.HasIndex(e => new { e.Tenant, e.Name }, "Customers_tenant_name_key").IsUnique();
+
+            entity.Property(e => e.Id).HasColumnName("id");
+            entity.Property(e => e.Name)
+                .HasMaxLength(255)
+                .HasColumnName("name");
+            entity.Property(e => e.Tenant).HasColumnName("tenant");
+
+            entity.HasOne(d => d.TenantNavigation).WithMany(p => p.Customers)
+                .HasForeignKey(d => d.Tenant)
+                .OnDelete(DeleteBehavior.ClientSetNull)
+                .HasConstraintName("Customers_tenant_fkey");
+        });
+
+        modelBuilder.Entity<Tenant>(entity =>
+        {
+            entity.HasKey(e => e.Id).HasName("Tenants_pkey");
+
+            entity.HasIndex(e => e.Name, "Tenants_name_key").IsUnique();
+
+            entity.Property(e => e.Id).HasColumnName("id");
+            entity.Property(e => e.Name)
+                .HasMaxLength(255)
+                .HasColumnName("name");
+        });
+
+        modelBuilder.Entity<Ticket>(entity =>
+        {
+            entity.HasKey(e => e.Id).HasName("Tickets_pkey");
+
+            entity.Property(e => e.Id).HasColumnName("id");
+            entity.Property(e => e.Customer).HasColumnName("customer");
+            entity.Property(e => e.Description).HasColumnName("description");
+            entity.Property(e => e.LastUpdated)
+                .HasDefaultValueSql("now()")
+                .HasColumnType("timestamp without time zone")
+                .HasColumnName("last_updated");
+            entity.Property(e => e.Resolved)
+                .HasDefaultValue(false)
+                .HasColumnName("resolved");
+            entity.Property(e => e.Tenant).HasColumnName("tenant");
+
+            entity.HasOne(d => d.CustomerNavigation).WithMany(p => p.Tickets)
+                .HasForeignKey(d => d.Customer)
+                .OnDelete(DeleteBehavior.ClientSetNull)
+                .HasConstraintName("Tickets_customer_fkey");
+
+            entity.HasOne(d => d.TenantNavigation).WithMany(p => p.Tickets)
+                .HasForeignKey(d => d.Tenant)
+                .OnDelete(DeleteBehavior.ClientSetNull)
+                .HasConstraintName("Tickets_tenant_fkey");
+
+            // Try manually designating the Navigation properties.
+            entity.Navigation(e => e.CustomerNavigation);
+            entity.Navigation(e => e.TenantNavigation);
+        });
+
+        OnModelCreatingPartial(modelBuilder);
+    }
+
+    partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
+}

--- a/server/aspnetcore/TicketHub/Database/Tenant.cs
+++ b/server/aspnetcore/TicketHub/Database/Tenant.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace TicketHub.Database;
+
+public partial class Tenant
+{
+    public int Id { get; set; }
+
+    public string? Name { get; set; }
+
+    public virtual ICollection<Customer> Customers { get; set; } = new List<Customer>();
+
+    public virtual ICollection<Ticket> Tickets { get; set; } = new List<Ticket>();
+}

--- a/server/aspnetcore/TicketHub/Database/Ticket.cs
+++ b/server/aspnetcore/TicketHub/Database/Ticket.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.AspNetCore.Authentication;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
+
+namespace TicketHub.Database;
+
+public partial class Ticket
+{
+    public int Id { get; set; }
+
+    public string? Description { get; set; }
+
+    [JsonProperty("last_updated")]
+    [JsonConverter(typeof(UtcDateTimeConverter))]
+    public DateTime LastUpdated { get; set; }
+
+    public bool Resolved { get; set; }
+
+    [JsonIgnore]
+    public int Customer { get; set; }
+
+    [JsonIgnore]
+    public int Tenant { get; set; }
+
+    [JsonIgnore]
+    public virtual Customer CustomerNavigation { get; set; } = null!;
+
+    [JsonIgnore]
+    public virtual Tenant TenantNavigation { get; set; } = null!;
+
+    [JsonProperty("customer")]
+    public string CustomerName => CustomerNavigation?.Name ?? "";
+
+    [JsonProperty("tenant")]
+    public string TenantName => TenantNavigation?.Name ?? "";
+}
+
+public class TicketConverter : JsonConverter
+{
+    public override bool CanConvert(Type objectType)
+    {
+        return objectType == typeof(Ticket);
+    }
+
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+    {
+        if (value is not null && value is Ticket ticket)
+        {
+            var jsonObject = JObject.FromObject(ticket, serializer);
+
+            // Remove unwanted properties
+            jsonObject.Remove("CustomerNavigation");
+            jsonObject.Remove("TenantNavigation");
+
+            // Replace CustomerId and TenantId with respective names
+            jsonObject["Customer"] = ticket.CustomerName;
+            jsonObject["Tenant"] = ticket.TenantName;
+
+            jsonObject.WriteTo(writer);
+        }
+        else
+        {
+            throw new JsonSerializationException("Null object provided.");
+        }
+    }
+
+    public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+public class UtcDateTimeConverter : IsoDateTimeConverter
+{
+    public UtcDateTimeConverter()
+    {
+        DateTimeFormat = "yyyy-MM-ddTHH:mm:ssZ";
+        DateTimeStyles = System.Globalization.DateTimeStyles.AssumeUniversal;
+    }
+}

--- a/server/aspnetcore/TicketHub/Program.cs
+++ b/server/aspnetcore/TicketHub/Program.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json;
 using TicketHub.Database;
 using Styra.Opa;
 using Styra.Opa.AspNetCore;
+using Microsoft.AspNetCore.Authentication;
 
 
 string opaURL = System.Environment.GetEnvironmentVariable("OPA_URL") ?? "http://localhost:8181";
@@ -19,12 +20,18 @@ builder.Services.AddControllers().AddNewtonsoftJson(opts =>
     opts.SerializerSettings.NullValueHandling = NullValueHandling.Ignore;
 });
 builder.Services.AddExceptionHandler<CustomExceptionHandler>();
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = "CustomCookieAuth";
+    options.DefaultChallengeScheme = "CustomCookieAuth";
+}).AddScheme<AuthenticationSchemeOptions, CustomCookieAuthenticationHandler>(
+    "CustomCookieAuth", options => { });
 
 // Create the top-level application.
 var app = builder.Build();
 
 // Wire in middleware.
-app.UseCookieAuthMiddleware();
+app.UseAuthentication();
 app.UseMiddleware<OpaAuthorizationMiddleware>(opa, "tickets/aspnetcore/main");
 app.MapControllers();
 

--- a/server/aspnetcore/TicketHub/Program.cs
+++ b/server/aspnetcore/TicketHub/Program.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Newtonsoft.Json;
+using TicketHub.Database;
+using Styra.Opa;
+using Styra.Opa.AspNetCore;
+
+
+string opaURL = System.Environment.GetEnvironmentVariable("OPA_URL") ?? "http://localhost:8181";
+OpaClient opa = new OpaClient(opaURL);
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the builder.
+builder.Services.AddDbContext<PostgresContext>();
+builder.Services.AddLogging(builder => builder.SetMinimumLevel(LogLevel.Trace).AddConsole());
+builder.Services.AddControllers().AddNewtonsoftJson(opts =>
+{
+    opts.SerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore;
+    opts.SerializerSettings.NullValueHandling = NullValueHandling.Ignore;
+});
+builder.Services.AddExceptionHandler<CustomExceptionHandler>();
+
+// Create the top-level application.
+var app = builder.Build();
+
+// Wire in middleware.
+app.UseCookieAuthMiddleware();
+app.UseMiddleware<OpaAuthorizationMiddleware>(opa, "tickets/aspnetcore/main");
+app.MapControllers();
+
+// Start up the server.
+app.Run();
+
+// Custom handler for exceptions, so that most of our unhandled exceptions will
+// appear as HTTP 500's.
+internal class CustomExceptionHandler : IExceptionHandler
+{
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext context,
+        Exception exception,
+        CancellationToken cancellation)
+    {
+        context.Response.StatusCode = 500;
+        var error = new { message = exception.Message };
+        await context.Response.WriteAsJsonAsync(error, cancellation);
+        return true;
+    }
+}

--- a/server/aspnetcore/TicketHub/TicketHub.csproj
+++ b/server/aspnetcore/TicketHub/TicketHub.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="NodaTime" Version="3.1.12" />
+    <PackageReference Include="Npgsql" Version="8.0.4" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.8" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="8.0.8" />
+    <PackageReference Include="Npgsql.Json.NET" Version="8.0.4" />
+    <PackageReference Include="Styra.Opa" Version="1.3.7" />
+    <PackageReference Include="Styra.Opa.AspNetCore" Version="0.1.7" />
+  </ItemGroup>
+
+</Project>

--- a/server/aspnetcore/TicketHub/appsettings.Development.json
+++ b/server/aspnetcore/TicketHub/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Styra.Opa.AspNetCore": "Trace"
+    }
+  }
+}

--- a/server/aspnetcore/TicketHub/appsettings.json
+++ b/server/aspnetcore/TicketHub/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Styra.Opa.AspNetCore": "Trace"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/server/aspnetcore/database/init.sql
+++ b/server/aspnetcore/database/init.sql
@@ -1,0 +1,44 @@
+CREATE TABLE "public"."Tenants" (
+  id SERIAL PRIMARY KEY NOT NULL,
+  name VARCHAR(255) UNIQUE
+);
+
+CREATE TABLE "public"."Customers" (
+  id SERIAL PRIMARY KEY NOT NULL,
+  tenant INTEGER NOT NULL,
+  name VARCHAR(255),
+  FOREIGN KEY ("tenant") REFERENCES "public"."Tenants"(id),
+  UNIQUE (tenant, name)
+);
+
+CREATE TABLE "public"."Tickets" (
+  id SERIAL PRIMARY KEY NOT NULL,
+  description TEXT,
+  last_updated TIMESTAMP NOT NULL DEFAULT now(),
+  resolved BOOLEAN NOT NULL DEFAULT false,
+  customer INTEGER NOT NULL,
+  tenant INTEGER NOT NULL,
+  FOREIGN KEY ("customer") REFERENCES "public"."Customers"(id),
+  FOREIGN KEY ("tenant") REFERENCES "public"."Tenants"(id)
+);
+
+INSERT INTO "Tenants" (name) VALUES ('hooli'), ('acmecorp');
+
+INSERT INTO "Customers" (tenant, name) VALUES
+  (2, 'Globex'),
+  (2, 'Sirius Cybernetics Corp.'),
+  (2, 'Cyberdyne Systems Corp.'),
+  (1, 'Soylent Corp.'),
+  (1, 'Tyrell Corp.');
+
+INSERT INTO "Tickets" (tenant, customer, description, resolved) VALUES
+  (2, 1, 'Dooms day device needs to be refactored', FALSE),
+  (2, 1, 'Flamethrower implementation is too heavyweight', TRUE),
+  (2, 2, 'Latest android exhibit depression tendencies', FALSE),
+  (2, 2, 'Happy Vertical People Transporters need to be more efficient in determining destination floor', FALSE),
+  (2, 3, 'Mimetic polyalloy becomes brittle at low temperatures', FALSE),
+  (2, 3, 'Temporal dislocation field reacts with exposed metal', TRUE),
+  (1, 4, 'Final ingredient for project ''Green'' still undecided', FALSE),
+  (1, 4, 'Customer service center switch board DDoS:ed by (opinionated) ingredient declaration inquiries', TRUE),
+  (1, 5, 'Replicants become too independent over time', FALSE),
+  (1, 5, 'Detective Rick Deckard''s billing address is unknown', FALSE);


### PR DESCRIPTION
## What changed?

This PR adds a new C# server implementation, one that leverages the [`Styra.Opa.AspNetCore`](https://github.com/StyraInc/opa-aspnetcore) middleware library. It also wires in the new server implementation into existing CI tests.

*Note: I owe a debt of gratitude to @charlesdaniels for putting together the Spring Boot policy, from which I derived 90%+ of the policy for the ASP.NET Core SDK server.*

## Implementation Notes

The main changes for the *TicketHub server* from the original C# SDK are:
 - Removed the custom `Authorization` attribute implementations for the controller.
 - Rewrote the custom cookie authentication system to integrate as an ASP.NET Authentication method.
   - This allows us to wire it into the app configuration, and later enable it with `app.UseAuthorization()`!

The main changes for the *policy* from the Spring Boot SDK's policy are:
 - URL paths are not truncated; we see the full `/api/tickets`, instead of just `/tickets`.
 - Headers returned from ASP.NET are *capitalized* by default (e.g. `Authorization`, instead of `authorization`).

The rest of the implementation work was pretty much identical to what is described on the [SDK How-to Guide](https://docs.styra.com/sdk/aspnetcore/how-to/add-sdk). :smile: 