### PR TITLE
implement reason support for Java backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,36 @@ Then open the browser at `http://localhost:3000`
 > Using docker compose requires `networking_mode: host`.
 > This is disabled by default on MacOS and Windows for Docker Desktop.
 > See the [Docker Desktop documentation](https://docs.docker.com/network/drivers/host/) for information on how to enable this mode.
+
+## Reason Support
+
+Some TicketHub servers and clients support displaying reason information to the user. This can be helpful for informing the user why their request failed. Reason information is accessed via `data.tickets.reason`. For purposes of this demo app, the `reason_admin` value is assigned to `reason`, though in a more production-ready application `reason_user` would be more appropriate. TicketHub backends which support reasons should provide a `reason` field in their JSON response body during HTTP 403 forbidden responses.
+
+For an example of how this works, consider the following curl commands:
+
+```plain
+$ curl -LSs 'http://localhost:4000/api/tickets/1/resolve' -H 'Cookie: user=acmecorp / bob' -H 'content-type: application/json'  --data-raw '{"resolved":true}' | jq
+{
+  "reason": "resolver role is required to resolve",
+  "message": "access denied by policy"
+}
+$ curl -LSs 'http://localhost:4000/api/tickets/1/resolve' -H 'Cookie: user=acmecorp / alice' -H 'content-type: application/json'  --data-raw '{"resolved":true}' | jq
+{
+  "description": "Dooms day device needs to be refactored",
+  "id": 1,
+  "customer": "Globex",
+  "resolved": true,
+  "last_updated": "2024-10-08T16:45:57.557846723Z"
+}
+```
+
+Reason support for clients:
+* ✅ HTML
+* ❌ React
+
+Reason support for servers:
+* ✅ Java
+* ❌ Spring Boot
+* ❌ C#
+* ❌ ASP.NET
+* ❌ Node

--- a/policies/tickets.rego
+++ b/policies/tickets.rego
@@ -14,17 +14,19 @@ allowed(user, tenant, action) if {
 }
 allowed(user, tenant, "resolve") if "resolver" in roles[tenant][user]
 
+reason := reason_admin
+
 default reason_user = "access is denied"
 default reason_admin = "admin role is required for unhandled actions"
 
-#reason_user = "access is permitted" if allow
+reason_user = "access is permitted" if allow
 reason_admin = "access is permitted" if allow
 
-#reason_user = r if {
-#       not allow
-#       input.action in {"get", "list"}
-#       r := "access is denied"
-#}
+reason_user = r if {
+       not allow
+       input.action in {"get", "list"}
+       r := "access is denied"
+}
 
 reason_admin = r if {
        not allow
@@ -32,11 +34,11 @@ reason_admin = r if {
        r := "reader role is required to get or list"
 }
 
-#reason_user = r if {
-#       not allow
-#       input.action in {"resolve"}
-#       r := "access is denied"
-#}
+reason_user = r if {
+       not allow
+       input.action in {"resolve"}
+       r := "access is denied"
+}
 
 reason_admin = r if {
        not allow
@@ -44,4 +46,3 @@ reason_admin = r if {
        r := "resolver role is required to resolve"
 }
 
-reason_user := reason_admin

--- a/server/java/src/main/java/com/styra/tickethub/ForbiddenExceptionWithReason.java
+++ b/server/java/src/main/java/com/styra/tickethub/ForbiddenExceptionWithReason.java
@@ -1,0 +1,17 @@
+package com.styra.tickethub;
+
+import jakarta.ws.rs.ForbiddenException;
+
+public class ForbiddenExceptionWithReason extends ForbiddenException {
+    private String reason;
+
+    public ForbiddenExceptionWithReason(String message, String reason) {
+        super(message);
+        this.reason = reason;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+}
+

--- a/server/java/src/main/java/com/styra/tickethub/ForbiddenExceptionWithReasonMapper.java
+++ b/server/java/src/main/java/com/styra/tickethub/ForbiddenExceptionWithReasonMapper.java
@@ -1,0 +1,48 @@
+package com.styra.tickethub;
+
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.MediaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Map.entry;
+
+@Provider
+public class ForbiddenExceptionWithReasonMapper implements ExceptionMapper<ForbiddenExceptionWithReason> {
+
+    @Override
+    public Response toResponse(ForbiddenExceptionWithReason exception) {
+
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, String> payload = new HashMap<>();
+        payload.put("message", exception.getMessage());
+
+        if (exception.getReason() != null) {
+            payload.put("reason", exception.getReason());
+        }
+
+        try {
+            String json = mapper.writeValueAsString(payload);
+
+            return Response.status(Response.Status.FORBIDDEN)
+                           .entity(json)
+                           .type(MediaType.APPLICATION_JSON)
+                           .build();
+
+        } catch (JsonProcessingException e) {
+
+            return Response.status(Response.Status.FORBIDDEN)
+                           .entity("{\"message\": \"exception while formatting JSON (this should never happen)\"}")
+                           .type(MediaType.APPLICATION_JSON)
+                           .build();
+
+        }
+
+    }
+}
+


### PR DESCRIPTION
This PR adds reason support to the Java server, leveraging the previous work I did to support it in the HTL client. It also updates the README with information about how reasons work in this demo.