### PR TITLE
server/node: fix opa-typescript ref to ucast-prisma package

### DIFF
--- a/server/node/package-lock.json
+++ b/server/node/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@prisma/client": "^5.21.1",
         "@styra/opa": "^1.6.0",
-        "@styra/ucast-prisma": "https://gitpkg.vercel.app/StyraInc/opa-typescript/packages/ucast-prisma?main&scripts.postinstall=npm%20install%20--ignore-scripts%20%26%26%20npm%20run%20build",
+        "@styra/ucast-prisma": "https://gitpkg.vercel.app/StyraInc/opa-typescript/packages/ucast-prisma?0fa61220841ef8cd5730f6de228b9311541f5e9b&scripts.postinstall=npm%20install%20--ignore-scripts%20%26%26%20npm%20run%20build",
         "@ucast/core": "^1.10.2",
         "command-line-args": "^6.0.0",
         "dotenv": "^16.0.0",
@@ -271,7 +271,7 @@
     },
     "node_modules/@styra/ucast-prisma": {
       "version": "0.0.1",
-      "resolved": "https://gitpkg.vercel.app/StyraInc/opa-typescript/packages/ucast-prisma?main&scripts.postinstall=npm%20install%20--ignore-scripts%20%26%26%20npm%20run%20build",
+      "resolved": "https://gitpkg.vercel.app/StyraInc/opa-typescript/packages/ucast-prisma?0fa61220841ef8cd5730f6de228b9311541f5e9b&scripts.postinstall=npm%20install%20--ignore-scripts%20%26%26%20npm%20run%20build",
       "integrity": "sha512-b2aDFx5r/2M8VXZnpo2Eg8vEErapMqi5QoarU74CnXbNJu+aSujhVU6LACbUv0VZMx5D4BO0FsxtrH+/TQ0LEg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",

--- a/server/node/package.json
+++ b/server/node/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@prisma/client": "^5.21.1",
     "@styra/opa": "^1.6.0",
-    "@styra/ucast-prisma": "https://gitpkg.vercel.app/StyraInc/opa-typescript/packages/ucast-prisma?main&scripts.postinstall=npm%20install%20--ignore-scripts%20%26%26%20npm%20run%20build",
+    "@styra/ucast-prisma": "https://gitpkg.vercel.app/StyraInc/opa-typescript/packages/ucast-prisma?0fa61220841ef8cd5730f6de228b9311541f5e9b&scripts.postinstall=npm%20install%20--ignore-scripts%20%26%26%20npm%20run%20build",
     "@ucast/core": "^1.10.2",
     "command-line-args": "^6.0.0",
     "dotenv": "^16.0.0",


### PR DESCRIPTION
Referring to "main" was a silly idea. Package integrity checks block all usage of unstable references like those. Pinning a specific commit now.