### PR TITLE
database+node+react: add assignee, for livelier conditions

### DIFF
--- a/client/react/src/UsersContext.js
+++ b/client/react/src/UsersContext.js
@@ -1,0 +1,16 @@
+import { useContext, useState, createContext } from "react";
+
+const UsersContext = createContext();
+
+const UsersProvider = ({ users: initial, children }) => {
+  const [users, setUsers] = useState(initial);
+  return (
+    <UsersContext.Provider value={{ users, setUsers }}>
+      {children}
+    </UsersContext.Provider>
+  );
+};
+
+export default UsersProvider;
+
+export const useUsers = () => useContext(UsersContext);

--- a/client/react/src/components/App.jsx
+++ b/client/react/src/components/App.jsx
@@ -7,6 +7,7 @@ import { OPAClient } from "@styra/opa";
 
 import { Types } from "../types";
 import "../style.css";
+import UsersProvider from "../UsersContext";
 
 const paths = {
   "/tickets/new": Types.NEW_TICKET,
@@ -84,8 +85,10 @@ export default function App() {
       batch={batch}
       retry={3}
     >
-      <Nav type={type} accounts={accounts} />
-      <Outlet />
+      <UsersProvider users={accounts[tenant]}>
+        <Nav type={type} accounts={accounts} />
+        <Outlet />
+      </UsersProvider>
     </AuthzProvider>
   );
 }

--- a/client/react/src/components/Assignee.jsx
+++ b/client/react/src/components/Assignee.jsx
@@ -18,6 +18,16 @@ export default function Assignee({ ticket }) {
 
   const handleAssigneeChange = (ticket, assignee) => {
     ticket.assignee = assignee;
+    if (assignee === "none") {
+      fetch(`/api/tickets/${ticket.id}/assign`, {
+        method: "DELETE",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${tenant} / ${user}`,
+        },
+      });
+      return;
+    }
     fetch(`/api/tickets/${ticket.id}/assign`, {
       method: "POST",
       headers: {

--- a/client/react/src/components/Assignee.jsx
+++ b/client/react/src/components/Assignee.jsx
@@ -1,0 +1,49 @@
+import { useAuthn } from "../AuthnContext";
+import { useUsers } from "../UsersContext";
+import { useAuthz } from "@styra/opa-react";
+
+export default function Assignee({ ticket }) {
+  const { user, tenant } = useAuthn();
+  const { users } = useUsers();
+  const usersSelect = users.map(({ name: value }) => ({
+    value,
+    label: capitalizeFirstLetter(value),
+  }));
+  usersSelect.unshift({ value: "none", label: "unassigned" });
+
+  const { result: authorizedAssigner } = useAuthz("tickets/allow", {
+    action: "assign",
+    resource: "ticket",
+  });
+
+  const handleAssigneeChange = (ticket, assignee) => {
+    ticket.assignee = assignee;
+    fetch(`/api/tickets/${ticket.id}/assign`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${tenant} / ${user}`,
+      },
+      body: JSON.stringify({ assignee }),
+    });
+  };
+
+  return (
+    <select
+      defaultValue={ticket.assignee}
+      onChange={(e) => handleAssigneeChange(ticket, e.target.value)}
+      disabled={!authorizedAssigner}
+    >
+      {usersSelect.map(({ value, label }) => (
+        <option key={value} value={value}>
+          {label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+// Thanks SO: https://stackoverflow.com/a/1026087/993018
+function capitalizeFirstLetter(val) {
+  return String(val).charAt(0).toUpperCase() + String(val).slice(1);
+}

--- a/client/react/src/components/Ticket.jsx
+++ b/client/react/src/components/Ticket.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useAuthn } from "../AuthnContext";
 import { Authz } from "@styra/opa-react";
+import Assignee from "./Assignee";
 
 export default function Ticket() {
   const { user, tenant } = useAuthn();
@@ -69,7 +70,9 @@ export default function Ticket() {
         <div id="description">{ticket.description}</div>
 
         <label htmlFor="assignee">Assignee</label>
-        <div id="assignee">{ticket.assignee || "unassigned"}</div>
+        <div id="assignee">
+          <Assignee ticket={ticket} />
+        </div>
 
         <label htmlFor="resolved">Resolved</label>
         <div id="resolved">{ticket.resolved ? "yes" : "no"}</div>

--- a/client/react/src/components/Ticket.jsx
+++ b/client/react/src/components/Ticket.jsx
@@ -68,6 +68,9 @@ export default function Ticket() {
         <label htmlFor="description">Description</label>
         <div id="description">{ticket.description}</div>
 
+        <label htmlFor="assignee">Assignee</label>
+        <div id="assignee">{ticket.assignee || "unassigned"}</div>
+
         <label htmlFor="resolved">Resolved</label>
         <div id="resolved">{ticket.resolved ? "yes" : "no"}</div>
 

--- a/client/react/src/components/Tickets.jsx
+++ b/client/react/src/components/Tickets.jsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuthn } from "../AuthnContext";
+import { useUsers } from "../UsersContext";
 import { Authz, useAuthz } from "@styra/opa-react";
 
 export default function Tickets() {
   const { user, tenant } = useAuthn();
+  const { users } = useUsers();
   const navigate = useNavigate();
   const [tickets, setTickets] = useState();
 
@@ -20,13 +22,11 @@ export default function Tickets() {
       .then((data) => setTickets(data.tickets));
   }, [tenant, user]);
 
-  // TODO(sr): take these from somewhere else
-  const users = [
-    { value: "none", label: "unassigned" },
-    { value: "alice", label: "Alice" },
-    { value: "bob", label: "Bob" },
-    { value: "ceasar", label: "Ceasar" },
-  ];
+  const usersSelect = users.map(({ name: value }) => ({
+    value,
+    label: capitalizeFirstLetter(value),
+  }));
+  usersSelect.unshift({ value: "none", label: "unassigned" });
 
   const { result: authorizedAssigner } = useAuthz("tickets/allow", {
     action: "assign",
@@ -79,7 +79,7 @@ export default function Tickets() {
                   onChange={(e) => handleAssigneeChange(ticket, e.target.value)}
                   disabled={!authorizedAssigner}
                 >
-                  {users.map(({ value, label }) => (
+                  {usersSelect.map(({ value, label }) => (
                     <option key={value} value={value}>
                       {label}
                     </option>
@@ -123,4 +123,9 @@ export default function Tickets() {
       </Authz>
     </main>
   );
+}
+
+// Thanks SO: https://stackoverflow.com/a/1026087/993018
+function capitalizeFirstLetter(val) {
+  return String(val).charAt(0).toUpperCase() + String(val).slice(1);
 }

--- a/client/react/src/components/Tickets.jsx
+++ b/client/react/src/components/Tickets.jsx
@@ -52,8 +52,10 @@ export default function Tickets() {
               <td>
                 <Assignee ticket={ticket} />
               </td>
-              <td>{ticket.resolved ? "yes" : "no"}</td>
-              <td>
+              <td onClick={() => navigate(`/tickets/${ticket.id}`)}>
+                {ticket.resolved ? "yes" : "no"}
+              </td>
+              <td onClick={() => navigate(`/tickets/${ticket.id}`)}>
                 <Authz
                   path={"tickets/allow"}
                   input={{ action: "resolve", resource: "ticket", ticket }}

--- a/client/react/src/components/Tickets.jsx
+++ b/client/react/src/components/Tickets.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuthn } from "../AuthnContext";
-import { Authz } from "@styra/opa-react";
+import { Authz, useAuthz } from "@styra/opa-react";
 
 export default function Tickets() {
   const { user, tenant } = useAuthn();
@@ -20,6 +20,19 @@ export default function Tickets() {
       .then((data) => setTickets(data.tickets));
   }, [tenant, user]);
 
+  // TODO(sr): take these from somewhere else
+  const users = [
+    { value: "none", label: "unassigned" },
+    { value: "alice", label: "Alice" },
+    { value: "bob", label: "Bob" },
+    { value: "ceasar", label: "Ceasar" },
+  ];
+
+  const { result: authorizedAssigner } = useAuthz("tickets/allow", {
+    action: "assign",
+    resource: "ticket",
+  });
+
   return (
     <main>
       <table id="ticket-list">
@@ -35,15 +48,37 @@ export default function Tickets() {
         </thead>
         <tbody>
           {tickets?.map((ticket) => (
-            <tr
-              key={ticket.id}
-              onClick={() => navigate(`/tickets/${ticket.id}`)}
-            >
-              <td>{ticket.id}</td>
-              <td>{ticket.last_updated}</td>
-              <td>{ticket.customer}</td>
-              <td>{ticket.description}</td>
-              <td>{ticket.assignee}</td>
+            <tr key={ticket.id}>
+              <td onClick={() => navigate(`/tickets/${ticket.id}`)}>
+                {ticket.id}
+              </td>
+              <td onClick={() => navigate(`/tickets/${ticket.id}`)}>
+                {ticket.last_updated}
+              </td>
+              <td onClick={() => navigate(`/tickets/${ticket.id}`)}>
+                {ticket.customer}
+              </td>
+              <td onClick={() => navigate(`/tickets/${ticket.id}`)}>
+                {ticket.description}
+              </td>
+              <td>
+                <select
+                  defaultValue={ticket.assignee}
+                  onChange={(e) => {
+                    ticket.assignee = e.target.value;
+                    alert(
+                      `Assigning ticket #${ticket.id} to ${ticket.assignee} (not supported yet)`,
+                    );
+                  }}
+                  disabled={!authorizedAssigner}
+                >
+                  {users.map(({ value, label }) => (
+                    <option key={value} value={value}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+              </td>
               <td>{ticket.resolved ? "yes" : "no"}</td>
               <td>
                 <Authz

--- a/client/react/src/components/Tickets.jsx
+++ b/client/react/src/components/Tickets.jsx
@@ -29,6 +29,7 @@ export default function Tickets() {
             <th>Last Updated</th>
             <th>Customer</th>
             <th>Description</th>
+            <th>Assignee</th>
             <th colSpan="2">Resolved</th>
           </tr>
         </thead>
@@ -42,6 +43,7 @@ export default function Tickets() {
               <td>{ticket.last_updated}</td>
               <td>{ticket.customer}</td>
               <td>{ticket.description}</td>
+              <td>{ticket.assignee}</td>
               <td>{ticket.resolved ? "yes" : "no"}</td>
               <td>
                 <Authz

--- a/client/react/src/components/Tickets.jsx
+++ b/client/react/src/components/Tickets.jsx
@@ -33,6 +33,18 @@ export default function Tickets() {
     resource: "ticket",
   });
 
+  const handleAssigneeChange = (ticket, assignee) => {
+    ticket.assignee = assignee;
+    fetch(`/api/tickets/${ticket.id}/assign`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${tenant} / ${user}`,
+      },
+      body: JSON.stringify({ assignee }),
+    });
+  };
+
   return (
     <main>
       <table id="ticket-list">
@@ -64,12 +76,7 @@ export default function Tickets() {
               <td>
                 <select
                   defaultValue={ticket.assignee}
-                  onChange={(e) => {
-                    ticket.assignee = e.target.value;
-                    alert(
-                      `Assigning ticket #${ticket.id} to ${ticket.assignee} (not supported yet)`,
-                    );
-                  }}
+                  onChange={(e) => handleAssigneeChange(ticket, e.target.value)}
                   disabled={!authorizedAssigner}
                 >
                   {users.map(({ value, label }) => (
@@ -90,6 +97,8 @@ export default function Tickets() {
                     </button>
                   }
                 >
+                  {/* NOTE(sr): This button does not work? It's just to show off disabled/enabled based on authz
+                   and batch queries. */}
                   <button type="submit">
                     {ticket.resolved ? "Unresolve" : "Resolve"}
                   </button>

--- a/policies/tickets.rego
+++ b/policies/tickets.rego
@@ -4,11 +4,11 @@ import rego.v1
 
 roles := data.roles
 
-response.allow := allow
+response["allow"] := allow
 
-response.reason := reason_admin
+response["reason"] := reason_admin
 
-response.conditions := conditions
+response["conditions"] := conditions
 
 default allow := false
 
@@ -32,9 +32,12 @@ user_is_resolver(user, tenant) if "resolver" in roles[tenant][user]
 
 ## CONDITIONS ##
 
-conditions.or contains {"tickets.resolved": false} if user_is_resolver(input.user, input.tenant)
-
-conditions.or contains {"users.name": input.user} if user_is_resolver(input.user, input.tenant)
+conditions["or"] := [
+	{"tickets.resolved": false},
+	{"users.name": input.user},
+] if {
+	user_is_resolver(input.user, input.tenant)
+}
 
 ## DENY REASONS ##
 

--- a/policies/tickets.rego
+++ b/policies/tickets.rego
@@ -5,10 +5,13 @@ import rego.v1
 roles := data.roles
 
 response.allow := allow
+
 response.reason := reason_admin
+
 response.conditions := conditions
 
 default allow := false
+
 allow if allowed(input.user, input.tenant, input.action)
 
 allowed(user, tenant, _) if "admin" in roles[tenant][user]
@@ -18,47 +21,47 @@ allowed(user, tenant, action) if {
 	some role in roles[tenant][user]
 	read_allowed(role)
 }
+
 allowed(user, tenant, "resolve") if user_is_resolver(user, tenant)
 
 read_allowed("reader")
+
 read_allowed("resolver")
 
 user_is_resolver(user, tenant) if "resolver" in roles[tenant][user]
 
 ## CONDITIONS ##
 
-conditions["tickets.resolved"] := false if user_is_resolver(input.user, input.tenant)
-#conditions["tickets.id"].ne := 2
+conditions.or contains {"tickets.resolved": false} if user_is_resolver(input.user, input.tenant)
 
-#conditions.or contains {"tickets.resolved": false} if user_is_resolver(input.user, input.tenant)
-#conditions.or contains {"tickets.id": {"ne": 2}}
-#conditions["customers.name"] := "Globex"
+conditions.or contains {"users.name": input.user} if user_is_resolver(input.user, input.tenant)
 
 ## DENY REASONS ##
 
 default reason_user := "access is denied"
+
 default reason_admin := "admin role is required for unhandled actions"
 
 reason_user := "access is permitted" if allow
+
 reason_admin := "access is permitted" if allow
 
 reason_user := "access is denied" if {
-       not allow
-       input.action in {"get", "list"}
+	not allow
+	input.action in {"get", "list"}
 }
 
 reason_admin := "reader role is required to get or list" if {
-       not allow
-       input.action in {"get", "list"}
+	not allow
+	input.action in {"get", "list"}
 }
 
 reason_user := "access is denied" if {
-       not allow
-       input.action in {"resolve"}
+	not allow
+	input.action in {"resolve"}
 }
 
 reason_admin := "resolver role is required to resolve" if {
-       not allow
-       input.action in {"resolve"}
+	not allow
+	input.action in {"resolve"}
 }
-

--- a/server/node/database/init.sql
+++ b/server/node/database/init.sql
@@ -34,7 +34,7 @@ CREATE TABLE "public"."Tickets" (
 
 INSERT INTO "Tenants" (id, name) VALUES (1, 'hooli'), (2, 'acmecorp');
 
-INSERT INTO "Users" (tenant, name) VALUES (2, 'alice'), (2, 'bob'), (2, 'ceasar'), (1, 'dylan');
+INSERT INTO "Users" (tenant, name) VALUES (2, 'alice'), (2, 'bob'), (2, 'ceasar'), (1, 'dylan'), (1, 'eva'), (1, 'frank');
 
 INSERT INTO "Customers" (tenant, name) VALUES
   (2, 'Globex'),

--- a/server/node/database/init.sql
+++ b/server/node/database/init.sql
@@ -11,6 +11,14 @@ CREATE TABLE "public"."Customers" (
   UNIQUE (tenant, name)
 );
 
+CREATE TABLE "public"."Users" (
+  id SERIAL PRIMARY KEY NOT NULL,
+  tenant INTEGER NOT NULL,
+  name VARCHAR(255),
+  FOREIGN KEY ("tenant") REFERENCES "public"."Tenants"(id),
+  UNIQUE (tenant, name)
+);
+
 CREATE TABLE "public"."Tickets" (
   id SERIAL PRIMARY KEY NOT NULL,
   description TEXT,
@@ -18,11 +26,15 @@ CREATE TABLE "public"."Tickets" (
   resolved BOOLEAN NOT NULL DEFAULT false,
   customer INTEGER NOT NULL,
   tenant INTEGER NOT NULL,
+  assignee INTEGER,
   FOREIGN KEY ("customer") REFERENCES "public"."Customers"(id),
-  FOREIGN KEY ("tenant") REFERENCES "public"."Tenants"(id)
+  FOREIGN KEY ("tenant") REFERENCES "public"."Tenants"(id),
+  FOREIGN KEY ("assignee") REFERENCES "public"."Users"(id)
 );
 
-INSERT INTO "Tenants" (name) VALUES ('hooli'), ('acmecorp');
+INSERT INTO "Tenants" (id, name) VALUES (1, 'hooli'), (2, 'acmecorp');
+
+INSERT INTO "Users" (tenant, name) VALUES (2, 'alice'), (2, 'bob'), (2, 'ceasar'), (1, 'dylan');
 
 INSERT INTO "Customers" (tenant, name) VALUES
   (2, 'Globex'),
@@ -31,14 +43,14 @@ INSERT INTO "Customers" (tenant, name) VALUES
   (1, 'Soylent Corp.'),
   (1, 'Tyrell Corp.');
 
-INSERT INTO "Tickets" (tenant, customer, description, resolved) VALUES
-  (2, 1, 'Dooms day device needs to be refactored', FALSE),
-  (2, 1, 'Flamethrower implementation is too heavyweight', TRUE),
-  (2, 2, 'Latest android exhibit depression tendencies', FALSE),
-  (2, 2, 'Happy Vertical People Transporters need to be more efficient in determining destination floor', FALSE),
-  (2, 3, 'Mimetic polyalloy becomes brittle at low temperatures', FALSE),
-  (2, 3, 'Temporal dislocation field reacts with exposed metal', TRUE),
-  (1, 4, 'Final ingredient for project ''Green'' still undecided', FALSE),
-  (1, 4, 'Customer service center switch board DDoS:ed by (opinionated) ingredient declaration inquiries', TRUE),
-  (1, 5, 'Replicants become too independent over time', FALSE),
-  (1, 5, 'Detective Rick Deckard''s billing address is unknown', FALSE);
+INSERT INTO "Tickets" (tenant, customer, description, resolved, assignee) VALUES
+  (2, 1, 'Dooms day device needs to be refactored', FALSE, 3),
+  (2, 1, 'Flamethrower implementation is too heavyweight', TRUE, 3),
+  (2, 2, 'Latest android exhibit depression tendencies', FALSE, 3),
+  (2, 2, 'Happy Vertical People Transporters need to be more efficient in determining destination floor', FALSE, NULL),
+  (2, 3, 'Mimetic polyalloy becomes brittle at low temperatures', FALSE, NULL),
+  (2, 3, 'Temporal dislocation field reacts with exposed metal', TRUE, NULL),
+  (1, 4, 'Final ingredient for project ''Green'' still undecided', FALSE, NULL),
+  (1, 4, 'Customer service center switch board DDoS:ed by (opinionated) ingredient declaration inquiries', TRUE, NULL),
+  (1, 5, 'Replicants become too independent over time', FALSE, NULL),
+  (1, 5, 'Detective Rick Deckard''s billing address is unknown', FALSE, NULL);

--- a/server/node/package-lock.json
+++ b/server/node/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@prisma/client": "^5.21.1",
         "@styra/opa": "^1.6.0",
-        "@styra/ucast-prisma": "^0.0.2",
+        "@styra/ucast-prisma": "^0.0.3",
         "@ucast/core": "^1.10.2",
         "command-line-args": "^6.0.1",
         "dotenv": "^16.0.0",
@@ -270,9 +270,10 @@
       }
     },
     "node_modules/@styra/ucast-prisma": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@styra/ucast-prisma/-/ucast-prisma-0.0.2.tgz",
-      "integrity": "sha512-Zz9OLZkzcGg7IVIFho82lFpzcIO+JLoEsoXpiOddFLqvTgajkQFGRXBAOQ/hPl3gXK0yZTTIQTr8Fvec/UHCZQ==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@styra/ucast-prisma/-/ucast-prisma-0.0.3.tgz",
+      "integrity": "sha512-DlrQmtEyY/EP2IU6DS0I4rWgoJs5fMJ7YD9EpuwnYZcGaXj3jHctJmsng0LklgqEg2+vtYx4QdklcD6R4tQgVQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@ucast/core": "^1.10.1",
         "lodash.merge": "^4.6.2"

--- a/server/node/package.json
+++ b/server/node/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@prisma/client": "^5.21.1",
     "@styra/opa": "^1.6.0",
-    "@styra/ucast-prisma": "^0.0.2",
+    "@styra/ucast-prisma": "^0.0.3",
     "@ucast/core": "^1.10.2",
     "command-line-args": "^6.0.1",
     "dotenv": "^16.0.0",

--- a/server/node/prisma/schema.prisma
+++ b/server/node/prisma/schema.prisma
@@ -24,8 +24,10 @@ model Tickets {
   resolved     Boolean   @default(false)
   customer     Int
   tenant       Int
+  assignee     Int?
   customers    Customers @relation(fields: [customer], references: [id], onDelete: NoAction, onUpdate: NoAction)
   tenants      Tenants   @relation(fields: [tenant], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  users        Users?    @relation(fields: [assignee], references: [id], onDelete: NoAction, onUpdate: NoAction)
 }
 
 model Tenants {
@@ -33,4 +35,15 @@ model Tenants {
   name      String?     @unique @db.VarChar(255)
   customers Customers[]
   tickets   Tickets[]
+  users     Users[]
+}
+
+model Users {
+  id      Int       @id @default(autoincrement())
+  tenant  Int
+  name    String?   @db.VarChar(255)
+  tenants Tenants   @relation(fields: [tenant], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  tickets Tickets[]
+
+  @@unique([tenant, name])
 }

--- a/server/node/src/api.js
+++ b/server/node/src/api.js
@@ -146,11 +146,8 @@ router.get("/tickets", async (req, res) => {
     req,
   );
   if (!allow) return res.status(FORBIDDEN).json({ reason });
-  console.dir({ allow, conditions }, { depth: null });
 
   const filters = ucastToPrisma(conditions, "tickets");
-  console.dir(filters, { depth: null });
-
   const tickets = (
     await prisma.tickets.findMany({
       where: {

--- a/server/node/src/api.js
+++ b/server/node/src/api.js
@@ -185,6 +185,9 @@ router.get("/tickets", async (req, res) => {
         ...filters,
       },
       ...includeRelations,
+      orderBy: {
+        last_updated: "desc",
+      },
     })
   ).map((ticket) => toTicket(ticket));
   return res.status(OK).json({ tickets });

--- a/server/node/src/api.js
+++ b/server/node/src/api.js
@@ -93,6 +93,36 @@ router.post(
   },
 );
 
+// unassign ticket
+router.delete(
+  "/tickets/:id/assign",
+  [param("id").isInt().toInt()],
+  async (req, res) => {
+    const {
+      params: { id },
+    } = req;
+    const { allow, reason } = await authz.authorized(
+      path,
+      { action: "unassign" },
+      req,
+    );
+    if (!allow) return res.status(FORBIDDEN).json({ reason });
+
+    const ticket = await prisma.tickets.update({
+      where: {
+        id,
+      },
+      data: {
+        users: {
+          disconnect: true,
+        },
+      },
+      ...includeRelations,
+    });
+    return res.status(OK).json(toTicket(ticket));
+  },
+);
+
 // create ticket
 router.post("/tickets", async (req, res) => {
   const { allow, reason } = await authz.authorized(

--- a/server/node/src/api.js
+++ b/server/node/src/api.js
@@ -100,17 +100,14 @@ router.get("/tickets", async (req, res) => {
   if (!allow) return res.status(FORBIDDEN).json({ reason });
   console.dir({ allow, conditions }, { depth: null });
 
-  const interpreted = ucastToPrisma(conditions);
-  console.dir(interpreted, { depth: null });
-
-  const { tickets: primary, ...extras } = interpreted;
+  const filters = ucastToPrisma(conditions, "tickets");
+  console.dir(filters, { depth: null });
 
   const tickets = (
     await prisma.tickets.findMany({
       where: {
         tenant: req.auth.tenant.id,
-        ...primary,
-        ...extras, // most likely empty
+        ...filters,
       },
       include: {
         customers: true,

--- a/server/node/src/api.js
+++ b/server/node/src/api.js
@@ -10,7 +10,7 @@ export const router = Router();
 const { OK, FORBIDDEN } = StatusCodes;
 
 const prisma = new PrismaClient({
-  log: ['query'],
+  log: ["query"],
 });
 const includeCustomers = { include: { customers: true } };
 
@@ -26,9 +26,12 @@ router.post(
     const {
       params: { id },
     } = req;
-    const { allow, reason } = await authz.authorized(path, { action: "resolve" }, req);
-    if (!allow)
-      return res.status(FORBIDDEN).json({reason});
+    const { allow, reason } = await authz.authorized(
+      path,
+      { action: "resolve" },
+      req,
+    );
+    if (!allow) return res.status(FORBIDDEN).json({ reason });
 
     const ticket = await prisma.tickets.update({
       where: { id },
@@ -44,10 +47,12 @@ router.post(
 
 // create ticket
 router.post("/tickets", async (req, res) => {
-  const { allow, reason } = await authz.authorized(path, { action: "create" }, req);
-  if (!allow)
-    return res.status(FORBIDDEN).json({reason});
-
+  const { allow, reason } = await authz.authorized(
+    path,
+    { action: "create" },
+    req,
+  );
+  if (!allow) return res.status(FORBIDDEN).json({ reason });
 
   const {
     auth: {
@@ -87,13 +92,16 @@ router.post("/tickets", async (req, res) => {
 
 // list all tickets
 router.get("/tickets", async (req, res) => {
-  const { allow, reason, conditions } = await authz.authorized(path, { action: "list" }, req);
-  if (!allow)
-    return res.status(FORBIDDEN).json({reason});
-  console.dir({allow, conditions}, {depth: null});
+  const { allow, reason, conditions } = await authz.authorized(
+    path,
+    { action: "list" },
+    req,
+  );
+  if (!allow) return res.status(FORBIDDEN).json({ reason });
+  console.dir({ allow, conditions }, { depth: null });
 
   const interpreted = ucastToPrisma(conditions);
-  console.dir(interpreted, {depth: null});
+  console.dir(interpreted, { depth: null });
 
   const { tickets: primary, ...extras } = interpreted;
 
@@ -104,7 +112,10 @@ router.get("/tickets", async (req, res) => {
         ...primary,
         ...extras, // most likely empty
       },
-      ...includeCustomers,
+      include: {
+        customers: true,
+        users: true,
+      },
     })
   ).map((ticket) => toTicket(ticket));
   return res.status(OK).json({ tickets });
@@ -115,9 +126,12 @@ router.get("/tickets/:id", [param("id").isInt().toInt()], async (req, res) => {
   const {
     params: { id },
   } = req;
-  const { allow, reason } = await authz.authorized(path, { action: "get", id }, req);
-  if (!allow)
-    return res.status(FORBIDDEN).json({reason});
+  const { allow, reason } = await authz.authorized(
+    path,
+    { action: "get", id },
+    req,
+  );
+  if (!allow) return res.status(FORBIDDEN).json({ reason });
 
   const ticket = await prisma.tickets.findUniqueOrThrow({
     where: { id },
@@ -130,6 +144,12 @@ function now() {
   return new Date().toISOString().split(".")[0] + "Z";
 }
 
-function toTicket({ customers: { name }, tenant: _1, ...rest }) {
-  return { ...rest, customer: name };
+function toTicket({
+  customers: { name: customer },
+  users,
+  assignee: _2,
+  tenant: _1,
+  ...rest
+}) {
+  return { ...rest, customer, assignee: users?.name };
 }

--- a/tests/api/conditions.hurl
+++ b/tests/api/conditions.hurl
@@ -8,7 +8,7 @@ Authorization: Bearer acmecorp / alice
 user: acmecorp / alice
 HTTP 200
 [Asserts]
-jsonpath "$.tickets" count >= 7 # fresh setup has 7 tickets
+jsonpath "$.tickets" count >= 6 # fresh setup has 6 tickets
 jsonpath "$.tickets[*].resolved" includes true # both resolved and unresolved tickets
 jsonpath "$.tickets[*].resolved" includes false
 [Captures]
@@ -25,5 +25,8 @@ skip: {{skip_conditions}}
 HTTP 200
 [Asserts]
 jsonpath "$.tickets" count < {{all_count}}
-jsonpath "$.tickets[*].resolved" not includes true
-
+# all those jsonpath expressions yield at most one-element arrays
+jsonpath "$.tickets[?(@.id == 4)].resolved" includes false
+jsonpath "$.tickets[?(@.id == 4)].assignee" not exists
+jsonpath "$.tickets[?(@.id == 2)].resolved" includes true
+jsonpath "$.tickets[?(@.id == 2)].assignee" includes "ceasar"

--- a/tests/e2e/tests/tickets.spec.ts
+++ b/tests/e2e/tests/tickets.spec.ts
@@ -24,11 +24,13 @@ test("bob can not create new tickets", async ({ page }) => {
   ).toBeDisabled();
 });
 
-test("ceasar can only see unresolved tickets", async ({ page }) => {
+test("ceasar can only see unresolved tickets and those assigned to them", async ({
+  page,
+}) => {
   test.skip(process.env.CONDITIONS != "true", "skipping conditions test");
   await page.goto(baseURL);
   await page.getByLabel("User").selectOption("ceasar");
-  await expect(page.locator("#ticket-list > tbody > tr ")).toHaveCount(4);
+  await expect(page.locator("#ticket-list > tbody > tr ")).toHaveCount(5);
 });
 
 test("select another tenant's user switches title and ticket list", async ({


### PR DESCRIPTION
Admin users can see and change assignments:

<img width="1274" alt="image" src="https://github.com/user-attachments/assets/9624e56a-1478-4572-9b3c-16e3973b4409">

---------------
Resolver users can now only see unresolved tickets **AND** all tickets assigned to them:

<img width="1283" alt="image" src="https://github.com/user-attachments/assets/51bdb17a-91f6-456f-afc5-9f5477b9b0cf">


### ⚠️ NOTE: Assignments only work with server/node at the moment