### PR TITLE
policies/tickets.rego: make conditions.or more idiomatic

### DIFF
--- a/policies/tickets.rego
+++ b/policies/tickets.rego
@@ -4,11 +4,11 @@ import rego.v1
 
 roles := data.roles
 
-response["allow"] := allow
+response.allow := allow
 
-response["reason"] := reason_admin
+response.reason := reason_admin
 
-response["conditions"] := conditions
+response.conditions := conditions
 
 default allow := false
 
@@ -32,12 +32,9 @@ user_is_resolver(user, tenant) if "resolver" in roles[tenant][user]
 
 ## CONDITIONS ##
 
-conditions["or"] := [
-	{"tickets.resolved": false},
-	{"users.name": input.user},
-] if {
-	user_is_resolver(input.user, input.tenant)
-}
+conditions.or contains {"tickets.resolved": false} if user_is_resolver(input.user, input.tenant)
+
+conditions.or contains {"users.name": input.user} if user_is_resolver(input.user, input.tenant)
 
 ## DENY REASONS ##
 


### PR DESCRIPTION
`@styra/ucast-prisma` v0.0.4 handles empty `or` conditions better, so we can write policies that build up `or` conditions -- which may then also be empty, if, for example, a more privileged user makes the request.

Previously, we'd run into a prisma error because it doesn't like being fed and empty `OR: []`.