### PR TITLE
policies: filter out assigned+unresolved tickets

### DIFF
--- a/policies/tickets.rego
+++ b/policies/tickets.rego
@@ -32,7 +32,9 @@ user_is_resolver(user, tenant) if "resolver" in roles[tenant][user]
 
 ## CONDITIONS ##
 
-conditions.or contains {"tickets.resolved": false} if user_is_resolver(input.user, input.tenant)
+conditions.or contains {"tickets.resolved": false, "tickets.assignee": null} if {
+	user_is_resolver(input.user, input.tenant)
+}
 
 conditions.or contains {"users.name": input.user} if user_is_resolver(input.user, input.tenant)
 

--- a/server/node/package-lock.json
+++ b/server/node/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@prisma/client": "^5.21.1",
         "@styra/opa": "^1.6.0",
-        "@styra/ucast-prisma": "^0.0.4",
+        "@styra/ucast-prisma": "^0.0.5",
         "@ucast/core": "^1.10.2",
         "command-line-args": "^6.0.1",
         "dotenv": "^16.0.0",
@@ -270,9 +270,10 @@
       }
     },
     "node_modules/@styra/ucast-prisma": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@styra/ucast-prisma/-/ucast-prisma-0.0.4.tgz",
-      "integrity": "sha512-+MtT3hhFbORH3kU9Vs1NqsLFU458Qj4ee0qmlURVQHFVH6f9yj5R/Tz46eJT0AVZbBuYx1Dzt4EV9tVXkM1Phg==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@styra/ucast-prisma/-/ucast-prisma-0.0.5.tgz",
+      "integrity": "sha512-Hlfnnszg8kfn0mitv9wC8FZmaDvFrCBcvq+mAUDoQsaEqEUzcJ7GBLx8Z+DJ28PHZxf9/uyXzjcMJbyHKB8Gmg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@ucast/core": "^1.10.1",
         "lodash.merge": "^4.6.2"

--- a/server/node/package.json
+++ b/server/node/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@prisma/client": "^5.21.1",
     "@styra/opa": "^1.6.0",
-    "@styra/ucast-prisma": "^0.0.4",
+    "@styra/ucast-prisma": "^0.0.5",
     "@ucast/core": "^1.10.2",
     "command-line-args": "^6.0.1",
     "dotenv": "^16.0.0",

--- a/tests/api/conditions.hurl
+++ b/tests/api/conditions.hurl
@@ -23,6 +23,8 @@ user: acmecorp / ceasar
 [Options]
 skip: {{skip_conditions}}
 HTTP 200
+[Captures]
+before_count: jsonpath "$.tickets" count
 [Asserts]
 jsonpath "$.tickets" count < {{all_count}}
 # all those jsonpath expressions yield at most one-element arrays
@@ -30,3 +32,38 @@ jsonpath "$.tickets[?(@.id == 4)].resolved" includes false
 jsonpath "$.tickets[?(@.id == 4)].assignee" not exists
 jsonpath "$.tickets[?(@.id == 2)].resolved" includes true
 jsonpath "$.tickets[?(@.id == 2)].assignee" includes "ceasar"
+
+# assign one unresolved ticket to bob
+POST http://{{host}}:4000/api/tickets/4/assign
+Content-Type: application/json
+Authorization: Bearer acmecorp / alice
+[Cookies]
+user: acmecorp / alice
+[Options]
+skip: {{skip_conditions}}
+{
+  "assignee": "bob"
+}
+HTTP 200
+
+# it'll disappear from ceasr's list
+GET http://{{host}}:4000/api/tickets
+Content-Type: application/json
+Authorization: Bearer acmecorp / ceasar
+[Cookies]
+user: acmecorp / ceasar
+[Options]
+skip: {{skip_conditions}}
+HTTP 200
+[Asserts]
+jsonpath "$.tickets" count < {{before_count}}
+jsonpath "$.tickets[?(@.id == 4)]" count == 0
+
+# reset
+DELETE http://{{host}}:4000/api/tickets/4/assign
+Content-Type: application/json
+Authorization: Bearer acmecorp / alice
+[Cookies]
+user: acmecorp / alice
+[Options]
+skip: {{skip_conditions}}


### PR DESCRIPTION
The conditions for resolver users have been changed: they can list tickets iff they are either assigned to them (status doesn't matter) OR unassigned+unresolved. So before, Ceasar would be able to see the unresolved tickets that had been assigned to Bob; now, they cannot.

----

needs https://github.com/StyraInc/opa-typescript/pull/343 ✔️ 
