### PR TITLE
policies+node: move tenant-check into WHERE conditions for "list"

### DIFF
--- a/server/node/src/api.js
+++ b/server/node/src/api.js
@@ -180,10 +180,7 @@ router.get("/tickets", async (req, res) => {
   const filters = ucastToPrisma(conditions, "tickets");
   const tickets = (
     await prisma.tickets.findMany({
-      where: {
-        tenant: req.auth.tenant.id,
-        ...filters,
-      },
+      where: filters,
       ...includeRelations,
       orderBy: {
         last_updated: "desc",

--- a/server/node/src/authz.js
+++ b/server/node/src/authz.js
@@ -17,7 +17,7 @@ export class Authorizer {
     input,
     {
       auth: {
-        tenant: { name: tenant }, // only feed tenant name to OPA
+        tenant, // feed complete tenant info into OPA
         subject: user,
       },
     },


### PR DESCRIPTION
With this change, **all** of our "list tickets" _where_ clauses are determined by the policy eval result, even the tenancy filter.