### PR TITLE
client/react: hide "assignee" dropdown when backend doesn't support it

### DIFF
--- a/client/react/Makefile
+++ b/client/react/Makefile
@@ -1,5 +1,5 @@
 compile:
-	npm install
+	npm ci
 
 run: compile
 	npm run start

--- a/client/react/src/components/Ticket.jsx
+++ b/client/react/src/components/Ticket.jsx
@@ -8,6 +8,7 @@ export default function Ticket() {
   const { user, tenant } = useAuthn();
   const { ticketId } = useParams();
   const [ticket, setTicket] = useState();
+  const [canAssign, setCanAssign] = useState(false);
   const [message, setMessage] = useState();
 
   const loadTicket = async function (ticketId, user, tenant, setTicket) {
@@ -25,6 +26,12 @@ export default function Ticket() {
     if (!user) return; // wait for user to be set
     loadTicket(ticketId, user, tenant, setTicket);
   }, [user, tenant, ticketId, setTicket]);
+
+  // figure out if the backend can do assignments
+  useEffect(() => {
+    if (!ticket || canAssign) return;
+    if ("assignee" in ticket) setCanAssign(true);
+  }, [ticket, canAssign, setCanAssign]);
 
   const handleSubmit = useCallback(
     async (event) => {
@@ -69,10 +76,14 @@ export default function Ticket() {
         <label htmlFor="description">Description</label>
         <div id="description">{ticket.description}</div>
 
-        <label htmlFor="assignee">Assignee</label>
-        <div id="assignee">
-          <Assignee ticket={ticket} />
-        </div>
+        {canAssign && (
+          <>
+            <label htmlFor="assignee">Assignee</label>
+            <div id="assignee">
+              <Assignee ticket={ticket} />
+            </div>
+          </>
+        )}
 
         <label htmlFor="resolved">Resolved</label>
         <div id="resolved">{ticket.resolved ? "yes" : "no"}</div>

--- a/client/react/src/components/Tickets.jsx
+++ b/client/react/src/components/Tickets.jsx
@@ -8,6 +8,7 @@ export default function Tickets() {
   const { user, tenant } = useAuthn();
   const navigate = useNavigate();
   const [tickets, setTickets] = useState();
+  const [canAssign, setCanAssign] = useState(false);
 
   useEffect(() => {
     if (!user) return;
@@ -21,6 +22,13 @@ export default function Tickets() {
       .then((data) => setTickets(data.tickets));
   }, [tenant, user]);
 
+  // figure out if the backend can do assignments
+  useEffect(() => {
+    if (!tickets || canAssign) return;
+    if (tickets.some(({ assignee }) => assignee == null || !!assignee))
+      setCanAssign(true);
+  }, [tickets, canAssign, setCanAssign]);
+
   return (
     <main>
       <table id="ticket-list">
@@ -30,7 +38,7 @@ export default function Tickets() {
             <th>Last Updated</th>
             <th>Customer</th>
             <th>Description</th>
-            <th>Assignee</th>
+            {canAssign && <th>Assignee</th>}
             <th colSpan="2">Resolved</th>
           </tr>
         </thead>
@@ -49,9 +57,11 @@ export default function Tickets() {
               <td onClick={() => navigate(`/tickets/${ticket.id}`)}>
                 {ticket.description}
               </td>
-              <td>
-                <Assignee ticket={ticket} />
-              </td>
+              {canAssign && (
+                <td>
+                  <Assignee ticket={ticket} />
+                </td>
+              )}
               <td onClick={() => navigate(`/tickets/${ticket.id}`)}>
                 {ticket.resolved ? "yes" : "no"}
               </td>

--- a/server/node/Makefile
+++ b/server/node/Makefile
@@ -1,5 +1,5 @@
 compile:
-	npm install
+	npm ci
 
 run: compile
 	npm run start:dev

--- a/server/node/src/api.js
+++ b/server/node/src/api.js
@@ -220,5 +220,5 @@ function toTicket({
   tenant: _1,
   ...rest
 }) {
-  return { ...rest, customer, assignee: users?.name };
+  return { ...rest, customer, assignee: users?.name || null };
 }

--- a/tests/api/conditions.hurl
+++ b/tests/api/conditions.hurl
@@ -29,7 +29,7 @@ before_count: jsonpath "$.tickets" count
 jsonpath "$.tickets" count < {{all_count}}
 # all those jsonpath expressions yield at most one-element arrays
 jsonpath "$.tickets[?(@.id == 4)].resolved" includes false
-jsonpath "$.tickets[?(@.id == 4)].assignee" not exists
+jsonpath "$.tickets[?(@.id == 4)].assignee" includes null
 jsonpath "$.tickets[?(@.id == 2)].resolved" includes true
 jsonpath "$.tickets[?(@.id == 2)].assignee" includes "ceasar"
 


### PR DESCRIPTION
Had to make server/node return `"assignee": null` to differentiate, but that's probably OK.