### PR TITLE
WIP: server/aspnetcore: Add initial UCAST->LINQ plumbing.

### DIFF
--- a/server/aspnetcore/TicketHub/Controllers/TicketController.cs
+++ b/server/aspnetcore/TicketHub/Controllers/TicketController.cs
@@ -1,10 +1,27 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using System.Linq.Expressions;
 using System.Net.Mime;
 using System.Security.Claims;
 using TicketHub.Database;
 
 namespace TicketHub.Controllers;
+
+public class UCASTNode
+{
+    [JsonProperty("type")]
+    public required string Type;
+
+    [JsonProperty("operation")]
+    public required string Op;
+
+    [JsonProperty("field")]
+    public string? Field;
+
+    [JsonProperty("value")]
+    public required object Value; // Either another string, or a List<UCASTNode>.
+}
 
 [ApiController]
 [Route("/api")]
@@ -107,6 +124,70 @@ public class TicketController : ControllerBase
 
     private async Task<Tenant> getTenantByName(string name)
     {
-        return await _dbContext.Tenants.Where(tenant => tenant.Name == name).FirstAsync();
+        //return await _dbContext.Tenants.Where(tenant => tenant.Name == name).FirstAsync(); // Original
+        // Attempt to use UCAST for the filtering here:
+        UCASTNode conditions = new UCASTNode() { Type = "field", Op = "eq", Field = "Name", Value = name };
+        return await _dbContext.Tenants.ApplyUCASTFilter(conditions).FirstAsync();
+    }
+}
+
+
+public static class QueryableExtensions
+{
+    public static IQueryable<T> ApplyUCASTFilter<T>(this IQueryable<T> source, UCASTNode root)
+    {
+        var parameter = Expression.Parameter(typeof(T), "SourceType");
+        var expression = BuildExpression<T>(root, parameter);
+        return source.Where(Expression.Lambda<Func<T, bool>>(expression, parameter));
+    }
+
+    private static Expression BuildExpression<T>(UCASTNode node, ParameterExpression parameter)
+    {
+        switch (node.Type.ToLower())
+        {
+            case "field":
+                return BuildFieldExpression<T>(node, parameter);
+            case "document":
+                return BuildFieldExpression<T>(node, parameter); // TODO: Fix this to provide actual document-level operations.
+            case "compound":
+                return BuildCompoundExpression<T>(node, parameter);
+            default:
+                throw new ArgumentException($"Unknown node type: {node.Type}");
+        }
+    }
+
+    private static Expression BuildFieldExpression<T>(UCASTNode node, ParameterExpression parameter)
+    {
+        var property = Expression.Property(parameter, node.Field!);
+        var value = Expression.Constant(node.Value); // TODO: Check that this reflects correctly.
+
+        // Switch expression:
+        return node.Op.ToLower() switch
+        {
+            "eq" => Expression.Equal(property, value),
+            "ne" => Expression.NotEqual(property, value),
+            "gt" => Expression.GreaterThan(property, value),
+            "ge" => Expression.GreaterThanOrEqual(property, value),
+            "gte" => Expression.GreaterThanOrEqual(property, value),
+            "lt" => Expression.LessThan(property, value),
+            "le" => Expression.LessThanOrEqual(property, value),
+            "lte" => Expression.LessThanOrEqual(property, value),
+            "contains" => Expression.Call(property, typeof(string).GetMethod("Contains", new[] { typeof(string) }), value),
+            _ => throw new ArgumentException($"Unknown operation: {node.Op}"),
+        };
+    }
+
+    private static Expression BuildCompoundExpression<T>(UCASTNode node, ParameterExpression parameter)
+    {
+        var childNodes = (List<UCASTNode>)node.Value;
+        var childExpressions = childNodes.Select(child => BuildExpression<T>(child, parameter));
+
+        // Switch expression:
+        return node.Op.ToLower() switch
+        {
+            "and" => childExpressions.Aggregate(Expression.AndAlso),
+            "or" => childExpressions.Aggregate(Expression.OrElse),
+            _ => throw new ArgumentException($"Unknown group operation: {node.Op}"),
+        };
     }
 }


### PR DESCRIPTION
## What changed?

This PR is a first stab at UCAST -> LINQ support, via the `IQueryable<T>` interface. There's a lot of TODOs, mostly around making sure the LINQ reflection stuff is working as-intended. Not everything works just yet!

Tables JOINs are also a big unknown, which I plan to at least look into, and maybe support with document-level ops (`include` or `join` would be good examples that hew close to existing LINQ stuff).

## References

 - https://learn.microsoft.com/en-us/dotnet/csharp/linq/how-to-build-dynamic-queries