### PR TITLE
server/csharp: Add initial stab at LINQ+UCAST support.

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -96,7 +96,7 @@ jobs:
       - name: Run hurl API tests
         run: docker compose run --quiet-pull integration-tests
         env:
-          HURL_SKIP_CONDITIONS: ${{ matrix.server != 'node' }}
+          HURL_SKIP_CONDITIONS: ${{ matrix.server != 'node' && matrix.server != 'csharp' }}
       - name: dump logs
         run: docker compose --profile ${{ matrix.server }} logs
         if: failure()

--- a/policies/tickets_expanded.rego
+++ b/policies/tickets_expanded.rego
@@ -38,19 +38,20 @@ user_is_resolver(user, tenant) if "resolver" in roles[tenant][user]
 
 conditions["type"] := "compound"
 conditions["operation"] := "and"
-conditions["value"] contains {"type": "field", "operation": "eq", "field": "tickets.resolved", "value": false} if {
-	user_is_resolver(input.user, tenant)
-}
 
+# Resolver conditions
 conditions["value"] contains {"type": "compound", "operation": "or", "value": v} if {
 	user_is_resolver(input.user, tenant)
 
-	v := [
-		{"type": "field", "operation": "eq", "field": "tickets.assignee", "value": null},
-		{"type": "field", "operation": "eq", "field": "users.name", "value": input.user}
+	v := [{"type": "compound", "operation": "and", "value": [
+			{"type": "field", "operation": "eq", "field": "tickets.resolved", "value": false},
+			{"type": "field", "operation": "eq", "field": "tickets.assignee", "value": null},
+		]},
+		{"type": "field", "operation": "eq", "field": "users.name", "value": input.user},
 	]
 }
 
+# Tenancy
 conditions["value"] contains {"type": "field", "operation": "eq", "field": "tickets.tenant", "value": input.tenant.id}
 
 # Tenancy

--- a/policies/tickets_expanded.rego
+++ b/policies/tickets_expanded.rego
@@ -1,0 +1,94 @@
+package tickets_expanded
+
+import rego.v1
+
+roles := data.roles
+
+response.allow := allow
+
+response.reason := reason_admin
+
+response.conditions := conditions
+
+# NOTE(sr): Support both server/node and the other backends -- node sends the tenant information
+# differently.
+tenant := object.get(input, ["tenant", "name"], input.tenant)
+
+default allow := false
+
+allow if allowed(input.user, tenant, input.action)
+
+allowed(user, tenant, _) if "admin" in roles[tenant][user]
+
+allowed(user, tenant, action) if {
+	action in {"get", "list"}
+	some role in roles[tenant][user]
+	read_allowed(role)
+}
+
+allowed(user, tenant, "resolve") if user_is_resolver(user, tenant)
+
+read_allowed("reader")
+
+read_allowed("resolver")
+
+user_is_resolver(user, tenant) if "resolver" in roles[tenant][user]
+
+## CONDITIONS ##
+
+conditions["type"] := "compound"
+conditions["operation"] := "and"
+conditions["value"] contains {"type": "field", "operation": "eq", "field": "tickets.resolved", "value": false} if {
+	user_is_resolver(input.user, tenant)
+}
+
+conditions["value"] contains {"type": "compound", "operation": "or", "value": v} if {
+	user_is_resolver(input.user, tenant)
+
+	v := [
+		{"type": "field", "operation": "eq", "field": "tickets.assignee", "value": null},
+		{"type": "field", "operation": "eq", "field": "users.name", "value": input.user}
+	]
+}
+
+conditions["value"] contains {"type": "field", "operation": "eq", "field": "tickets.tenant", "value": input.tenant.id}
+
+# Tenancy
+# conditions["tickets.tenant"] := input.tenant.id
+
+# Resolver conditions
+# conditions.or contains {"tickets.resolved": false, "tickets.assignee": null} if {
+# 	user_is_resolver(input.user, tenant)
+# }
+
+# conditions.or contains {"users.name": input.user} if user_is_resolver(input.user, tenant)
+
+## DENY REASONS ##
+
+default reason_user := "access is denied"
+
+default reason_admin := "admin role is required for unhandled actions"
+
+reason_user := "access is permitted" if allow
+
+reason_admin := "access is permitted" if allow
+
+reason_user := "access is denied" if {
+	not allow
+	input.action in {"get", "list"}
+}
+
+reason_admin := "reader role is required to get or list" if {
+	not allow
+	input.action in {"get", "list"}
+}
+
+reason_user := "access is denied" if {
+	not allow
+	input.action in {"resolve"}
+}
+
+reason_admin := "resolver role is required to resolve" if {
+	not allow
+	input.action in {"resolve"}
+}

--- a/server/csharp/Dockerfile
+++ b/server/csharp/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /TicketHub
 # Copy everything
 COPY . ./
 # Restore as distinct layers
-RUN dotnet restore
+RUN dotnet build --verbosity=detailed
 # Build and publish a release
 RUN dotnet publish -c Release -o out
 
@@ -12,5 +12,5 @@ RUN dotnet publish -c Release -o out
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:8.0
 WORKDIR /TicketHub
 COPY --from=build-env /TicketHub/out .
-ENTRYPOINT ["dotnet", "TicketHub.dll", "--urls", "http://0.0.0.0:4000"]
+ENTRYPOINT ["dotnet", "TicketHub.dll", "--urls", "http://0.0.0.0:4000", "--logger", "console;verbosity=detailed"]
 

--- a/server/csharp/TicketHub/Authorization/QueryableExtensions.cs
+++ b/server/csharp/TicketHub/Authorization/QueryableExtensions.cs
@@ -5,13 +5,6 @@ namespace TicketHub.Authorization;
 
 public static class QueryableExtensions
 {
-    public static Expression UCASTToLINQ<T>(UCASTNode root, Dictionary<string, Func<ParameterExpression, Expression>> mapper)
-    {
-        var parameter = Expression.Parameter(typeof(T), "x");
-        var expression = BuildExpression<T>(root, parameter, mapper);
-        return Expression.Lambda<Func<T, bool>>(expression, parameter);
-    }
-
     // Builds a LINQ Lambda Expression from the UCAST tree, and then invokes it under a LINQ Where expression on some queryable source collection.
     // In our case, this *should* usually be an EF Core ORM model.
     public static IQueryable<T> ApplyUCASTFilter<T>(this IQueryable<T> source, UCASTNode root, Dictionary<string, Func<ParameterExpression, Expression>> mapper)
@@ -21,7 +14,7 @@ public static class QueryableExtensions
         return source.Where(Expression.Lambda<Func<T, bool>>(expression, parameter));
     }
 
-    private static Expression BuildExpression<T>(UCASTNode node, ParameterExpression parameter, Dictionary<string, Func<ParameterExpression, Expression>> mapper)
+    public static Expression BuildExpression<T>(UCASTNode node, ParameterExpression parameter, Dictionary<string, Func<ParameterExpression, Expression>> mapper)
     {
         // Switch expression:
         return node.Type.ToLower() switch

--- a/server/csharp/TicketHub/Authorization/QueryableExtensions.cs
+++ b/server/csharp/TicketHub/Authorization/QueryableExtensions.cs
@@ -1,0 +1,89 @@
+
+using System.Linq.Expressions;
+
+namespace TicketHub.Authorization;
+
+public static class QueryableExtensions
+{
+    public static Expression UCASTToLINQ<T>(UCASTNode root, Dictionary<string, Func<ParameterExpression, Expression>> mapper)
+    {
+        var parameter = Expression.Parameter(typeof(T), "x");
+        var expression = BuildExpression<T>(root, parameter, mapper);
+        return Expression.Lambda<Func<T, bool>>(expression, parameter);
+    }
+
+    // Builds a LINQ Lambda Expression from the UCAST tree, and then invokes it under a LINQ Where expression on some queryable source collection.
+    // In our case, this *should* usually be an EF Core ORM model.
+    public static IQueryable<T> ApplyUCASTFilter<T>(this IQueryable<T> source, UCASTNode root, Dictionary<string, Func<ParameterExpression, Expression>> mapper)
+    {
+        var parameter = Expression.Parameter(typeof(T), "x");
+        var expression = BuildExpression<T>(root, parameter, mapper);
+        return source.Where(Expression.Lambda<Func<T, bool>>(expression, parameter));
+    }
+
+    private static Expression BuildExpression<T>(UCASTNode node, ParameterExpression parameter, Dictionary<string, Func<ParameterExpression, Expression>> mapper)
+    {
+        // Switch expression:
+        return node.Type.ToLower() switch
+        {
+            "field" => BuildFieldExpression<T>(node, parameter, mapper),
+            "document" => BuildFieldExpression<T>(node, parameter, mapper), // TODO: Fix this to provide actual document-level operations.
+            "compound" => BuildCompoundExpression<T>(node, parameter, mapper),
+            _ => throw new ArgumentException($"Unknown node type: {node.Type}"),
+        };
+    }
+
+    private static Expression BuildFieldExpression<T>(UCASTNode node, ParameterExpression parameter, Dictionary<string, Func<ParameterExpression, Expression>> mapper)
+    {
+        // TODO: Look up the FieldInfo that matches the string, slam it into the spot where it belongs.
+        //var property = mapper[node.Field!];
+        var property = mapper[node.Field!](parameter); // TODO: Replace with TryGet
+        // Introspect the PropertyExpression, and extract the type of the thing the property is coming from.
+
+        Expression value = Expression.Constant(node.Value); // TODO: Check that this reflects correctly.
+
+        Type lhsType = property.Type;
+        Type rhsType = value.Type;
+        if (lhsType != rhsType)
+        {
+            // Upcast smaller numeric type from System.Int32 -> System.Int64.
+            if (lhsType == typeof(int) && rhsType == typeof(long))
+            {
+                property = Expression.Convert(property, typeof(long));
+            }
+            else if (lhsType == typeof(long) && rhsType == typeof(int))
+            {
+                value = Expression.Convert(value, typeof(long));
+            }
+        }
+
+        // Switch expression:
+        return node.Op.ToLower() switch
+        {
+            "eq" => Expression.Equal(property, value),
+            "ne" => Expression.NotEqual(property, value),
+            "gt" => Expression.GreaterThan(property, value),
+            "ge" => Expression.GreaterThanOrEqual(property, value),
+            "gte" => Expression.GreaterThanOrEqual(property, value),
+            "lt" => Expression.LessThan(property, value),
+            "le" => Expression.LessThanOrEqual(property, value),
+            "lte" => Expression.LessThanOrEqual(property, value),
+            "contains" => Expression.Call(property, typeof(string).GetMethod("Contains", new[] { typeof(string) }), value),
+            _ => throw new ArgumentException($"Unknown operation: {node.Op}"),
+        };
+    }
+
+    private static Expression BuildCompoundExpression<T>(UCASTNode node, ParameterExpression parameter, Dictionary<string, Func<ParameterExpression, Expression>> mapper)
+    {
+        var childNodes = (List<UCASTNode>)node.Value;
+        var childExpressions = childNodes.Select(child => BuildExpression<T>(child, parameter, mapper));
+
+        // Switch expression:
+        return node.Op.ToLower() switch
+        {
+            "and" => childExpressions.Aggregate(Expression.AndAlso),
+            "or" => childExpressions.Aggregate(Expression.OrElse),
+            _ => throw new ArgumentException($"Unknown group operation: {node.Op}"),
+        };
+    }
+}

--- a/server/csharp/TicketHub/Authorization/UCASTNode.cs
+++ b/server/csharp/TicketHub/Authorization/UCASTNode.cs
@@ -1,0 +1,50 @@
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace TicketHub.Authorization;
+
+public class UCASTNode
+{
+    [JsonProperty("type")]
+    public required string Type;
+
+    [JsonProperty("operation")]
+    public required string Op;
+
+    [JsonProperty("field")]
+    public string? Field;
+
+    [JsonProperty("value")]
+    [JsonConverter(typeof(UCASTNodeValueConverter))]
+    public object? Value; // Either another string, or a List<UCASTNode>.
+}
+
+public class UCASTNodeValueConverter : JsonConverter
+{
+    public override bool CanConvert(Type objectType)
+    {
+        return objectType == typeof(object);
+    }
+
+    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+    {
+        JToken token = JToken.Load(reader);
+        if (token.Type == JTokenType.Array)
+        {
+            return token.ToObject<List<UCASTNode>>();
+        }
+
+        return token.ToObject<object>();
+    }
+
+    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+    {
+        serializer.Serialize(writer, value);
+    }
+
+    // public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+    // {
+    //     throw new NotImplementedException();
+    // }
+}

--- a/server/csharp/TicketHub/Controllers/TicketController.cs
+++ b/server/csharp/TicketHub/Controllers/TicketController.cs
@@ -64,7 +64,7 @@ public class TicketController : ControllerBase
     // List all tickets.
     [HttpGet]
     [Route("tickets")]
-    [OpaRuleAuthorization("tickets/allow", "list")]
+    [OpaRuleAuthorization("tickets_expanded/allow", "list")]
     public async Task<ActionResult<IAsyncEnumerable<Ticket>>> ListTickets()
     {
         var tName = HttpContext.Items["Tenant"]?.ToString();
@@ -102,7 +102,7 @@ public class TicketController : ControllerBase
             }
 
             // Log the condition expression for debugging, with a dummy target parameter.
-            _logger.LogDebug(QueryableExtensions.BuildExpression<Ticket>(conditions, Expression.Parameter(typeof(Ticket), "x"), mapper).ToString());
+            _logger.LogInformation(QueryableExtensions.BuildExpression<Ticket>(conditions, Expression.Parameter(typeof(Ticket), "x"), mapper).ToString());
 
             List<Ticket> tickets = await _dbContext.Tickets
                 .Include(t => t.CustomerNavigation)
@@ -199,8 +199,8 @@ public class TicketController : ControllerBase
 
     public struct PolicyResult
     {
-        [JsonProperty("authorized")]
-        public bool Authorized;
+        [JsonProperty("allow")]
+        public bool Allow;
 
         [JsonProperty("reason")]
         public string Reason;

--- a/server/csharp/TicketHub/Controllers/TicketController.cs
+++ b/server/csharp/TicketHub/Controllers/TicketController.cs
@@ -1,6 +1,12 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using Styra.Opa;
+using System.Linq.Expressions;
 using System.Net.Mime;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Runtime.CompilerServices;
 using TicketHub.Authorization;
 using TicketHub.Database;
 
@@ -33,23 +39,89 @@ public class TicketController : ControllerBase
         _dbContext = dbContext;
     }
 
+    public static Dictionary<string, Dictionary<string, FieldInfo>> CreateFieldInfoMapping(params Type[] dbSetTypes)
+    {
+        var mapping = new Dictionary<string, Dictionary<string, FieldInfo>>();
+
+        foreach (var dbSetType in dbSetTypes)
+        {
+            var entityType = dbSetType.GetGenericArguments()[0];
+            var fieldInfos = entityType.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var fieldMapping = new Dictionary<string, FieldInfo>();
+            foreach (var fieldInfo in fieldInfos)
+            {
+                fieldMapping[fieldInfo.Name] = fieldInfo;
+            }
+
+            mapping[entityType.Name] = fieldMapping;
+        }
+
+        return mapping;
+    }
+
     // List all tickets.
     [HttpGet]
     [Route("tickets")]
     [OpaRuleAuthorization("tickets/allow", "list")]
     public async Task<ActionResult<IAsyncEnumerable<Ticket>>> ListTickets()
     {
+        //_logger.LogInformation("{0}", JsonConvert.SerializeObject(result));
         var tName = HttpContext.Items["Tenant"]?.ToString();
+        string subject = HttpContext.Items["Subject"]?.ToString() ?? "";
+        //var mapper = TicketExpressionMapper.CreateMapping();
+        var userExpr = Expression.Parameter(typeof(User), "user");
+        var ticketExpr = Expression.Parameter(typeof(Ticket), "ticket");
+
+        // TODO: Refactor the QueryableExtension stuff to allow mapping from a source parameter expression?
+        // Ex: Something like Func<ParameterExpression, string> -> PropertyExpression
+        // These mappings will need to exist for each possible model that queries would be based off of.
+        // It's inconvenient, but that's the price we pay for building on top of LINQ, as best I can tell.
+
+        var mapper = new Dictionary<string, Func<ParameterExpression, Expression>>()
+        {
+            { "tickets.id", t => Expression.Property(t, "Id") },
+            { "tickets.customer", t => Expression.Property(t, "Customer") },
+            { "tickets.customer.name", t => Expression.Property(t, "CustomerName") },
+            { "tickets.tenant", t => Expression.Property(t, "Tenant") },
+            { "tickets.tenant.name", t => Expression.Property(t, "TenantName") },
+            { "tickets.assignee", t => Expression.Property(t, "Assignee") },
+            { "tickets.assignee.name", t => Expression.Property(t, "UserName") },
+            { "tickets.description", t => Expression.Property(t, "Description") },
+            { "tickets.resolved", t => Expression.Property(t, "Resolved") },
+            { "tickets.last_updated", t => Expression.Property(t, "LastUpdated") },
+            { "users.id", t => Expression.Property(Expression.Property(t, "UserNavigation"), "Id") },
+            { "users.name", t => Expression.Property(Expression.Property(t, "UserNavigation"), "Name") },
+            { "users.tenant", t => Expression.Property(Expression.Property(t, "UserNavigation"), "Tenant") },
+        };
         if (tName is string)
         {
             Tenant tenant = await getTenantByName(tName);
+            var conditions = await getConditions(HttpContext, "tickets_expanded/response", new Dictionary<string, object>(){
+                { "tenant", tenant },
+                { "user", subject },
+                { "action", "list" },
+            });
+            if (conditions is null)
+            {
+                return StatusCode(500, "No tickets found");
+            }
+            else
+            {
+                _logger.LogCritical("conditions is: {0}", conditions);
+            }
+
+            _logger.LogCritical(QueryableExtensions.UCASTToLINQ<Ticket>(conditions, mapper).ToString());
+
             List<Ticket> tickets = await _dbContext.Tickets
                 .Include(t => t.CustomerNavigation)
                 .Include(t => t.TenantNavigation)
-                .Where(t => t.Tenant == tenant.Id)
+                .Include(t => t.UserNavigation)
+                .ApplyUCASTFilter(conditions, mapper)
                 .ToListAsync();
             return Ok(new { Tickets = tickets });
         }
+
         return StatusCode(500, "No tickets found");
     }
 
@@ -72,7 +144,6 @@ public class TicketController : ControllerBase
     [OpaRuleAuthorization("tickets/allow", "create")]
     public async Task<ActionResult<Ticket>> CreateTicket([FromBody] TicketFields tf)
     {
-
         string tenant = HttpContext.Items["Tenant"]?.ToString() ?? "";
         Ticket ticket = new();
         // Fetch tenant, then create customer if needed.
@@ -111,5 +182,27 @@ public class TicketController : ControllerBase
     private async Task<Tenant> getTenantByName(string name)
     {
         return await _dbContext.Tenants.Where(tenant => tenant.Name == name).FirstAsync();
+    }
+
+    public struct PolicyResult
+    {
+        [JsonProperty("authorized")]
+        public bool Authorized;
+
+        [JsonProperty("reason")]
+        public string Reason;
+
+        [JsonProperty("conditions", NullValueHandling = NullValueHandling.Ignore)]
+        public UCASTNode? Conditions;
+    }
+
+    private async Task<UCASTNode?> getConditions(HttpContext context, string path, object input)
+    {
+        var authzService = context.RequestServices.GetRequiredService<OpaAuthzService>();
+        OpaClient opa = authzService.GetClient();
+
+        PolicyResult result = await opa.evaluate<PolicyResult>(path, input);
+        _logger.LogInformation(JsonConvert.SerializeObject(result));
+        return result.Conditions;
     }
 }

--- a/server/csharp/TicketHub/Database/Customer.cs
+++ b/server/csharp/TicketHub/Database/Customer.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace TicketHub.Database;
+﻿namespace TicketHub.Database;
 
 public partial class Customer
 {

--- a/server/csharp/TicketHub/Database/PostgresContext.cs
+++ b/server/csharp/TicketHub/Database/PostgresContext.cs
@@ -33,7 +33,7 @@ public partial class PostgresContext : DbContext
         {
             entity.HasKey(e => e.Id).HasName("Users_pkey");
 
-            entity.HasIndex(e => new { e.Tenant, e.Name }, "Users_tenant_name_key").IsUnique();
+            entity.HasIndex(e => new { e.Tenant, e.Name }, "Users_tenant_and_name_key").IsUnique();
 
             entity.Property(e => e.Id).HasColumnName("id");
             entity.Property(e => e.Name)
@@ -83,6 +83,8 @@ public partial class PostgresContext : DbContext
 
             entity.Property(e => e.Id).HasColumnName("id");
             entity.Property(e => e.Customer).HasColumnName("customer");
+            entity.Property(e => e.Tenant).HasColumnName("tenant");
+            entity.Property(e => e.Assignee).HasColumnName("assignee");
             entity.Property(e => e.Description).HasColumnName("description");
             entity.Property(e => e.LastUpdated)
                 .HasDefaultValueSql("now()")
@@ -91,8 +93,6 @@ public partial class PostgresContext : DbContext
             entity.Property(e => e.Resolved)
                 .HasDefaultValue(false)
                 .HasColumnName("resolved");
-            entity.Property(e => e.Tenant).HasColumnName("tenant");
-            entity.Property(e => e.Assignee).HasColumnName("assignee");
 
             entity.HasOne(d => d.CustomerNavigation).WithMany(p => p.Tickets)
                 .HasForeignKey(d => d.Customer)
@@ -107,7 +107,7 @@ public partial class PostgresContext : DbContext
             entity.HasOne(d => d.UserNavigation).WithMany(p => p.Tickets)
                 .HasForeignKey(d => d.Assignee)
                 .OnDelete(DeleteBehavior.ClientSetNull)
-                .HasConstraintName("Tickets_user_fkey");
+                .HasConstraintName("Tickets_assignee_fkey");
 
             // Try manually designating the Navigation properties.
             entity.Navigation(e => e.CustomerNavigation);

--- a/server/csharp/TicketHub/Database/PostgresContext.cs
+++ b/server/csharp/TicketHub/Database/PostgresContext.cs
@@ -19,6 +19,8 @@ public partial class PostgresContext : DbContext
 
     public virtual DbSet<Ticket> Tickets { get; set; }
 
+    public virtual DbSet<User> Users { get; set; }
+
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         string pgConnString = Environment.GetEnvironmentVariable("DATABASE_CONN_STR") ?? "Host=localhost;Database=postgres;Username=postgres;Password=schmickethub";
@@ -27,6 +29,24 @@ public partial class PostgresContext : DbContext
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
+        modelBuilder.Entity<User>(entity =>
+        {
+            entity.HasKey(e => e.Id).HasName("Users_pkey");
+
+            entity.HasIndex(e => new { e.Tenant, e.Name }, "Users_tenant_name_key").IsUnique();
+
+            entity.Property(e => e.Id).HasColumnName("id");
+            entity.Property(e => e.Name)
+                .HasMaxLength(255)
+                .HasColumnName("name");
+            entity.Property(e => e.Tenant).HasColumnName("tenant");
+
+            entity.HasOne(d => d.TenantNavigation).WithMany(p => p.Users)
+                .HasForeignKey(d => d.Tenant)
+                .OnDelete(DeleteBehavior.ClientSetNull)
+                .HasConstraintName("Users_tenant_fkey");
+        });
+
         modelBuilder.Entity<Customer>(entity =>
         {
             entity.HasKey(e => e.Id).HasName("Customers_pkey");
@@ -72,6 +92,7 @@ public partial class PostgresContext : DbContext
                 .HasDefaultValue(false)
                 .HasColumnName("resolved");
             entity.Property(e => e.Tenant).HasColumnName("tenant");
+            entity.Property(e => e.Assignee).HasColumnName("assignee");
 
             entity.HasOne(d => d.CustomerNavigation).WithMany(p => p.Tickets)
                 .HasForeignKey(d => d.Customer)
@@ -83,9 +104,15 @@ public partial class PostgresContext : DbContext
                 .OnDelete(DeleteBehavior.ClientSetNull)
                 .HasConstraintName("Tickets_tenant_fkey");
 
+            entity.HasOne(d => d.UserNavigation).WithMany(p => p.Tickets)
+                .HasForeignKey(d => d.Assignee)
+                .OnDelete(DeleteBehavior.ClientSetNull)
+                .HasConstraintName("Tickets_user_fkey");
+
             // Try manually designating the Navigation properties.
             entity.Navigation(e => e.CustomerNavigation);
             entity.Navigation(e => e.TenantNavigation);
+            entity.Navigation(e => e.UserNavigation);
         });
 
         OnModelCreatingPartial(modelBuilder);

--- a/server/csharp/TicketHub/Database/Tenant.cs
+++ b/server/csharp/TicketHub/Database/Tenant.cs
@@ -1,15 +1,21 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Newtonsoft.Json;
 
 namespace TicketHub.Database;
 
 public partial class Tenant
 {
+    [JsonProperty("id")]
     public int Id { get; set; }
 
+    [JsonProperty("name")]
     public string? Name { get; set; }
 
+    [JsonProperty("customers")]
     public virtual ICollection<Customer> Customers { get; set; } = new List<Customer>();
 
+    [JsonProperty("users")]
+    public virtual ICollection<User> Users { get; set; } = new List<User>();
+
+    [JsonProperty("tickets")]
     public virtual ICollection<Ticket> Tickets { get; set; } = new List<Ticket>();
 }

--- a/server/csharp/TicketHub/Database/Ticket.cs
+++ b/server/csharp/TicketHub/Database/Ticket.cs
@@ -41,7 +41,7 @@ public partial class Ticket
     [JsonProperty("tenant")]
     public string TenantName => TenantNavigation?.Name ?? "";
 
-    [JsonProperty("assignee")]
+    [JsonProperty("assignee", NullValueHandling = NullValueHandling.Include)]
     public string? UserName => UserNavigation?.Name;
 }
 

--- a/server/csharp/TicketHub/Database/User.cs
+++ b/server/csharp/TicketHub/Database/User.cs
@@ -1,0 +1,14 @@
+namespace TicketHub.Database;
+
+public partial class User
+{
+    public int Id { get; set; }
+
+    public int Tenant { get; set; }
+
+    public string? Name { get; set; }
+
+    public virtual Tenant TenantNavigation { get; set; } = null!;
+
+    public virtual ICollection<Ticket> Tickets { get; set; } = new List<Ticket>();
+}

--- a/server/csharp/database/init.sql
+++ b/server/csharp/database/init.sql
@@ -11,6 +11,14 @@ CREATE TABLE "public"."Customers" (
   UNIQUE (tenant, name)
 );
 
+CREATE TABLE "public"."Users" (
+  id SERIAL PRIMARY KEY NOT NULL,
+  tenant INTEGER NOT NULL,
+  name VARCHAR(255),
+  FOREIGN KEY ("tenant") REFERENCES "public"."Tenants"(id),
+  UNIQUE (tenant, name)
+);
+
 CREATE TABLE "public"."Tickets" (
   id SERIAL PRIMARY KEY NOT NULL,
   description TEXT,
@@ -18,11 +26,15 @@ CREATE TABLE "public"."Tickets" (
   resolved BOOLEAN NOT NULL DEFAULT false,
   customer INTEGER NOT NULL,
   tenant INTEGER NOT NULL,
+  assignee INTEGER,
   FOREIGN KEY ("customer") REFERENCES "public"."Customers"(id),
-  FOREIGN KEY ("tenant") REFERENCES "public"."Tenants"(id)
+  FOREIGN KEY ("tenant") REFERENCES "public"."Tenants"(id),
+  FOREIGN KEY ("assignee") REFERENCES "public"."Users"(id)
 );
 
-INSERT INTO "Tenants" (name) VALUES ('hooli'), ('acmecorp');
+INSERT INTO "Tenants" (id, name) VALUES (1, 'hooli'), (2, 'acmecorp');
+
+INSERT INTO "Users" (tenant, name) VALUES (2, 'alice'), (2, 'bob'), (2, 'ceasar'), (1, 'dylan'), (1, 'eva'), (1, 'frank');
 
 INSERT INTO "Customers" (tenant, name) VALUES
   (2, 'Globex'),
@@ -31,14 +43,14 @@ INSERT INTO "Customers" (tenant, name) VALUES
   (1, 'Soylent Corp.'),
   (1, 'Tyrell Corp.');
 
-INSERT INTO "Tickets" (tenant, customer, description, resolved) VALUES
-  (2, 1, 'Dooms day device needs to be refactored', FALSE),
-  (2, 1, 'Flamethrower implementation is too heavyweight', TRUE),
-  (2, 2, 'Latest android exhibit depression tendencies', FALSE),
-  (2, 2, 'Happy Vertical People Transporters need to be more efficient in determining destination floor', FALSE),
-  (2, 3, 'Mimetic polyalloy becomes brittle at low temperatures', FALSE),
-  (2, 3, 'Temporal dislocation field reacts with exposed metal', TRUE),
-  (1, 4, 'Final ingredient for project ''Green'' still undecided', FALSE),
-  (1, 4, 'Customer service center switch board DDoS:ed by (opinionated) ingredient declaration inquiries', TRUE),
-  (1, 5, 'Replicants become too independent over time', FALSE),
-  (1, 5, 'Detective Rick Deckard''s billing address is unknown', FALSE);
+INSERT INTO "Tickets" (tenant, customer, description, resolved, assignee) VALUES
+  (2, 1, 'Dooms day device needs to be refactored', FALSE, 3),
+  (2, 1, 'Flamethrower implementation is too heavyweight', TRUE, 3),
+  (2, 2, 'Latest android exhibit depression tendencies', FALSE, 3),
+  (2, 2, 'Happy Vertical People Transporters need to be more efficient in determining destination floor', FALSE, NULL),
+  (2, 3, 'Mimetic polyalloy becomes brittle at low temperatures', FALSE, NULL),
+  (2, 3, 'Temporal dislocation field reacts with exposed metal', TRUE, NULL),
+  (1, 4, 'Final ingredient for project ''Green'' still undecided', FALSE, NULL),
+  (1, 4, 'Customer service center switch board DDoS:ed by (opinionated) ingredient declaration inquiries', TRUE, NULL),
+  (1, 5, 'Replicants become too independent over time', FALSE, NULL),
+  (1, 5, 'Detective Rick Deckard''s billing address is unknown', FALSE, NULL);


### PR DESCRIPTION
## What changed?

This PR embodies the suite of changes required to integrate UCAST with LINQ queries. I've picked the C# server as the initial "landing zone" for these changes, since it's easier to pare back the layers here than in the ASP.NET Core SDK server.

## How to test?

Spin up the `csharp` server using:

    # Parallel build, and then run the csharp TicketHub server.
    docker compose build server-csharp --parallel && docker compose --profile csharp up

### Manual Querying with `curl`

If all went well, you should be able to query the TicketHub server directly with `curl`, as shown below:

```bash
curl --header 'Content-Type: application/json' --header 'Authorization: Bearer acmecorp / ceasar' --cookie 'user=acmecorp / ceasar' 'http://localhost:4000/api/tickets'
```
<details>
<summary>Example Output</summary>

```json
{"tickets":[{"id":3,"description":"Latest android exhibit depression tendencies","last_updated":"2024-11-27T20:34:17Z","resolved":false,"customer":"Sirius Cybernetics Corp.","tenant":"acmecorp","assignee":"ceasar"},{"id":2,"description":"Flamethrower implementation is too heavyweight","last_updated":"2024-11-27T20:34:17Z","resolved":true,"customer":"Globex","tenant":"acmecorp","assignee":"ceasar"},{"id":1,"description":"Dooms day device needs to be refactored","last_updated":"2024-11-27T20:34:17Z","resolved":false,"customer":"Globex","tenant":"acmecorp","assignee":"ceasar"},{"id":5,"description":"Mimetic polyalloy becomes brittle at low temperatures","last_updated":"2024-11-27T20:34:17Z","resolved":false,"customer":"Cyberdyne Systems Corp.","tenant":"acmecorp","assignee":null},{"id":4,"description":"Happy Vertical People Transporters need to be more efficient in determining destination floor","last_updated":"2024-11-27T20:34:17Z","resolved":false,"customer":"Sirius Cybernetics Corp.","tenant":"acmecorp","assignee":null}]}
```
</details>

Here's what the logs should generally look like from the `docker compose` side for the C# server:

```
server-csharp-1  | info: TicketHub.Controllers.TicketController[0]
server-csharp-1  |       {"allow":true,"reason":"access is permitted","conditions":{"type":"compound","operation":"and","field":null,"value":[{"type":"field","operation":"eq","field":"tickets.tenant","value":2},{"type":"compound","operation":"or","field":null,"value":[{"type":"compound","operation":"and","field":null,"value":[{"type":"field","operation":"eq","field":"tickets.resolved","value":false},{"type":"field","operation":"eq","field":"tickets.assignee","value":null}]},{"type":"field","operation":"eq","field":"users.name","value":"ceasar"}]}]}}
server-csharp-1  | info: TicketHub.Controllers.TicketController[0]
server-csharp-1  |       ((Convert(x.Tenant, Int64) == 2) AndAlso (((x.Resolved == False) AndAlso (x.Assignee == null)) OrElse (x.UserNavigation.Name == "ceasar")))
server-csharp-1  | info: Microsoft.EntityFrameworkCore.Database.Command[20101]
server-csharp-1  |       Executed DbCommand (3ms) [Parameters=[], CommandType='Text', CommandTimeout='30']
server-csharp-1  |       SELECT t.id, t.assignee, t.customer, t.description, t.last_updated, t.resolved, t.tenant, c.id, c.name, c.tenant, t0.id, t0.name, u.id, u.name, u.tenant
server-csharp-1  |       FROM "Tickets" AS t
server-csharp-1  |       LEFT JOIN "Users" AS u ON t.assignee = u.id
server-csharp-1  |       INNER JOIN "Customers" AS c ON t.customer = c.id
server-csharp-1  |       INNER JOIN "Tenants" AS t0 ON t.tenant = t0.id
server-csharp-1  |       WHERE t.tenant::bigint = 2 AND ((NOT (t.resolved) AND t.assignee IS NULL) OR u.name = 'ceasar')
```

We can see the translation stages, which run through the following stages:
 1. UCAST conditions JSON
 1. LINQ Expression tree
 1. SQL query generated by EF Core

The JSON blob returned to the `curl` command is the set of tickets retrieved from the database, after applying the UCAST filters.

### Integration Tests

Run the integration tests (with conditions tests turned on) using:

    HURL_SKIP_CONDITIONS=false docker compose run --remove-orphans --rm integration-tests

### Cleanup
When you're done viewing the results, remember to kill the server containers, and then run:

    docker compose --profile csharp down

For the cleanup. :broom: 

## Known Limitations

Currently, the user has to provide the mappings for each EF Core Model field they want to be able to write conditions over. For this application, it's just mappings relative to the `Ticket` model, but for larger applications, this could be quite ugly indeed.

The main reason why multiple distinct mappings might have to be created is because EF Core models are queried via LINQ, the LINQ part of the deal expects all `Expression`s to be constructed *relative* to some base `IQueryable<T>` source, usually represented as a `ParameterExpression` type. To try to be generic over all possible such queries, we require the user to supply the mappings at the top-level, before starting the Expression tree construction.
