### PR TITLE
ci: enable conditions PW tests for C#

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -85,7 +85,7 @@ jobs:
         run: npx playwright test
         working-directory: tests/e2e
         env:
-          CONDITIONS: ${{ matrix.server == 'node' }}
+          CONDITIONS: ${{ matrix.server == 'node' || matrix.server == 'csharp' }}
           REASONS: ${{ matrix.server == 'node' || matrix.server == 'java' }}
       - uses: actions/upload-artifact@v4
         if: always()

--- a/client/react/src/components/App.jsx
+++ b/client/react/src/components/App.jsx
@@ -22,7 +22,7 @@ const titles = {
 };
 
 export default function App() {
-  let [searchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const [batch] = useState(
     () => searchParams.get("batch") === "true",
     [searchParams],
@@ -73,7 +73,7 @@ export default function App() {
           document.cookie = `user=${tenant0} / ${user0}; Path=/; SameSite=Lax`;
         }
       });
-  }, [user]);
+  }, [user, setUser, setTenant]);
 
   if (!user || !tenant) return <div>Loading</div>;
 

--- a/client/react/src/components/Tickets.jsx
+++ b/client/react/src/components/Tickets.jsx
@@ -19,7 +19,14 @@ export default function Tickets() {
       },
     })
       .then((res) => res.json())
-      .then((data) => setTickets(data.tickets));
+      .then(({ tickets }) => {
+        tickets.sort(
+          (a, b) =>
+            new Date(b.last_updated).getTime() -
+            new Date(a.last_updated).getTime(),
+        );
+        setTickets(tickets);
+      });
   }, [tenant, user]);
 
   // figure out if the backend can do assignments
@@ -27,7 +34,7 @@ export default function Tickets() {
     if (!tickets || canAssign) return;
     if (tickets.some(({ assignee }) => assignee == null || !!assignee))
       setCanAssign(true);
-  }, [tickets, canAssign, setCanAssign]);
+  }, [tickets, canAssign]);
 
   return (
     <main>
@@ -44,7 +51,7 @@ export default function Tickets() {
         </thead>
         <tbody>
           {tickets?.map((ticket) => (
-            <tr key={ticket.id} id={`ticket-${ticket.id}`} >
+            <tr key={ticket.id} id={`ticket-${ticket.id}`}>
               <td onClick={() => navigate(`/tickets/${ticket.id}`)}>
                 {ticket.id}
               </td>

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.44.1",
-        "@types/node": "^22.1.0"
+        "@types/node": "^22.10.1"
       }
     },
     "node_modules/@playwright/test": {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -9,6 +9,6 @@
   "license": "ISC",
   "devDependencies": {
     "@playwright/test": "^1.44.1",
-    "@types/node": "^22.1.0"
+    "@types/node": "^22.10.1"
   }
 }

--- a/tests/e2e/tests/tickets.spec.ts
+++ b/tests/e2e/tests/tickets.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from "@playwright/test";
 
-const baseURL = `http://127.0.0.1:3000/?batch=${process.env.BATCHING == "true"}`;
+const baseURL = `http://127.0.0.1:3000/?batch=${process.env.BATCHING === "true"}`;
+const conditionsDisabled = process.env.CONDITIONS !== "true";
+const reasonsDisabled = process.env.REASONS !== "true";
 
 test("has title with tenant and list of tickets", async ({ page }) => {
   await page.goto(baseURL);
@@ -34,7 +36,7 @@ test("select another tenant's user switches title and ticket list", async ({
 });
 
 test.describe("data filtering using conditions", () => {
-  test.skip(process.env.CONDITIONS != "true", "skipping conditions test");
+  test.skip(conditionsDisabled, "skipping conditions test");
 
   const unassignTicket5 = async ({ page }) => {
     await page.goto(baseURL);
@@ -45,22 +47,29 @@ test.describe("data filtering using conditions", () => {
   test.beforeEach(unassignTicket5);
   test.afterEach(unassignTicket5);
 
-  test("ceasar can only see unresolved tickets and those assigned to them", async ({ page }) => {
+  test("ceasar can only see unresolved tickets and those assigned to them", async ({
+    page,
+  }) => {
     await page.goto(baseURL);
     await page.getByLabel("User").selectOption("ceasar");
     await expect(page.locator("#ticket-list > tbody > tr ")).toHaveCount(5);
 
     await page.getByLabel("User").selectOption("alice");
+    const assign = page.waitForResponse(
+      (response) =>
+        response.url().endsWith("assign") &&
+        response.request().method() === "POST",
+    );
     await page.locator("#ticket-5 select").selectOption("Bob");
+    await assign;
 
     await page.getByLabel("User").selectOption("ceasar");
     await expect(page.locator("#ticket-list > tbody > tr ")).toHaveCount(4);
   });
 });
 
-
 test.describe("showing reasons for denials", () => {
-  test.skip(process.env.REASONS != "true", "skipping reasons test");
+  test.skip(reasonsDisabled, "skipping reasons test");
 
   const unresolveTicket1 = async ({ page }) => {
     await page.goto(baseURL);
@@ -68,7 +77,7 @@ test.describe("showing reasons for denials", () => {
     await page.getByLabel("User").selectOption("alice");
 
     const resolved = await page.locator("#resolved").textContent();
-    if (resolved == "yes") {
+    if (resolved === "yes") {
       await page.getByRole("button", { name: "Resolve" }).click();
     }
   };
@@ -76,14 +85,20 @@ test.describe("showing reasons for denials", () => {
   test.beforeEach(unresolveTicket1);
   test.afterEach(unresolveTicket1);
 
-  test("bob gets an error message when trying to resolve the ticket", async ({ page }) => {
+  test("bob gets an error message when trying to resolve the ticket", async ({
+    page,
+  }) => {
     await page.goto(baseURL);
     await page.locator("#ticket-5 td:nth-child(1)").click();
     await page.getByLabel("User").selectOption("bob");
     const resolveButton = page.getByRole("button", { name: "Resolve" });
-    await resolveButton.evaluate(element => element.removeAttribute("disabled"));
+    await resolveButton.evaluate((element) =>
+      element.removeAttribute("disabled"),
+    );
 
     await resolveButton.click();
-    await expect(page.locator(".update-status")).toContainText("resolver role is required to resolve");
+    await expect(page.locator(".update-status")).toContainText(
+      "resolver role is required to resolve",
+    );
   });
 });


### PR DESCRIPTION
Turns out it's not been related to the ordering of tickets in the list view -- we had already taken precautions for that. It's been a timing issue. Adding a "wait for API request to finish" type of step in the relevant test, and it seems to be enough. After all, the behaviour of the C# backend and the react client was OK, it just failed the test.

Kept the sorting anyways, most recently updated tickets come first.