### PR TITLE
server/csharp: UCAST+LINQ refactors + default mapping logic

### DIFF
--- a/server/csharp/TicketHub/Authorization/QueryableExtensions.cs
+++ b/server/csharp/TicketHub/Authorization/QueryableExtensions.cs
@@ -35,7 +35,7 @@ public static class QueryableExtensions
         return node.Type.ToLower() switch
         {
             "field" => BuildFieldExpression<T>(node, parameter, mapper),
-            "document" => BuildFieldExpression<T>(node, parameter, mapper), // TODO: Fix this to provide actual document-level operations.
+            "document" => BuildFieldExpression<T>(node, parameter, mapper), // TODO: Fix this to provide actual document-level operations once we have any.
             "compound" => BuildCompoundExpression<T>(node, parameter, mapper),
             _ => throw new ArgumentException($"Unknown node type: {node.Type}"),
         };
@@ -55,12 +55,8 @@ public static class QueryableExtensions
     /// <returns>Result, a LINQ Expression (Usually a BinaryExpression).</returns>
     private static Expression BuildFieldExpression<T>(UCASTNode node, ParameterExpression parameter, Dictionary<string, Func<ParameterExpression, Expression>> mapper)
     {
-        // TODO: Look up the FieldInfo that matches the string, slam it into the spot where it belongs.
-        //var property = mapper[node.Field!];
-        var property = mapper[node.Field!](parameter); // TODO: Replace with TryGet
-        // Introspect the PropertyExpression, and extract the type of the thing the property is coming from.
-
-        Expression value = Expression.Constant(node.Value); // TODO: Check that this reflects correctly.
+        var property = mapper[node.Field!](parameter); // Note: This will throw a KeyNotFoundException if the field name does not exist.
+        Expression value = Expression.Constant(node.Value);
 
         Type lhsType = property.Type;
         Type rhsType = value.Type;

--- a/server/csharp/TicketHub/Authorization/QueryableExtensions.cs
+++ b/server/csharp/TicketHub/Authorization/QueryableExtensions.cs
@@ -58,6 +58,7 @@ public static class QueryableExtensions
         var property = mapper[node.Field!](parameter); // Note: This will throw a KeyNotFoundException if the field name does not exist.
         Expression value = Expression.Constant(node.Value);
 
+        // TODO: Add more robust type mismatch handling and possibly exceptions.
         Type lhsType = property.Type;
         Type rhsType = value.Type;
         if (lhsType != rhsType)
@@ -100,6 +101,7 @@ public static class QueryableExtensions
     /// <returns>Result, an aggregate LINQ Expression.</returns>
     private static Expression BuildCompoundExpression<T>(UCASTNode node, ParameterExpression parameter, Dictionary<string, Func<ParameterExpression, Expression>> mapper)
     {
+        // TODO: Detect wrong types, and/or empty child condition lists.
         var childNodes = (List<UCASTNode>)node.Value;
         var childExpressions = childNodes.Select(child => BuildExpression<T>(child, parameter, mapper));
 

--- a/server/csharp/TicketHub/Authorization/UCASTNode.cs
+++ b/server/csharp/TicketHub/Authorization/UCASTNode.cs
@@ -42,9 +42,4 @@ public class UCASTNodeValueConverter : JsonConverter
     {
         serializer.Serialize(writer, value);
     }
-
-    // public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-    // {
-    //     throw new NotImplementedException();
-    // }
 }

--- a/server/csharp/TicketHub/Database/Ticket.cs
+++ b/server/csharp/TicketHub/Database/Ticket.cs
@@ -89,20 +89,3 @@ public class UtcDateTimeConverter : IsoDateTimeConverter
         DateTimeStyles = System.Globalization.DateTimeStyles.AssumeUniversal;
     }
 }
-
-public class TicketExpressionMapper
-{
-    public static Dictionary<string, Expression<Func<Ticket, object>>> CreateMapping()
-    {
-        return new Dictionary<string, Expression<Func<Ticket, object>>>
-        {
-            ["tickets.id"] = t => t.Id,
-            ["tickets.description"] = t => t.Description,
-            ["tickets.last_updated"] = t => t.LastUpdated,
-            ["tickets.resolved"] = t => t.Resolved,
-            ["tickets.customer"] = t => t.CustomerName,
-            ["tickets.tenant"] = t => t.TenantName,
-            ["tickets.assignee"] = t => t.UserName,
-        };
-    }
-}


### PR DESCRIPTION
## What changed?

This PR includes some basic dead-code cleanups, along with a new "default mapping" utility, which handles converting EF Core model classes into property mapping dictionaries, in a way that makes sense, based on our current UCAST conditions policies.

Example translations of class property names -> UCAST property names:
- `Example.Id` -> `"example.id"`
- `Example.LastUpdated` -> `"example.last_updated"`
- `Example.UserNavigation.Id` -> `"example.user.id"`

This makes creating property mappings *enormously* less of a hassle for LINQ/EF Core use cases.

### Further examples

The PR shows how to manually add/remove keys from the mapper, because the conditons policy expects `users.name`, instead of `tickets.user.name`, for example. Here's the list of default keys generated by the mapper function:

<details>
<summary><b>Click to expand the default mappings list</b></summary>

Note: `Param_0` is the `ParameterExpression` that the lambda will later map to the current LINQ query target.

```
tickets.id => Param_0.Id
tickets.description => Param_0.Description
tickets.last_updated => Param_0.LastUpdated
tickets.resolved => Param_0.Resolved
tickets.customer => Param_0.Customer
tickets.tenant => Param_0.Tenant
tickets.assignee => Param_0.Assignee
tickets.customer.id => Param_0.CustomerNavigation.Id
tickets.customer.tenant => Param_0.CustomerNavigation.Tenant
tickets.customer.name => Param_0.CustomerNavigation.Name
tickets.customer.tickets => Param_0.CustomerNavigation.Tickets
tickets.tenant.id => Param_0.TenantNavigation.Id
tickets.tenant.name => Param_0.TenantNavigation.Name
tickets.tenant.customers => Param_0.TenantNavigation.Customers
tickets.tenant.users => Param_0.TenantNavigation.Users
tickets.tenant.tickets => Param_0.TenantNavigation.Tickets
tickets.user.id => Param_0.UserNavigation.Id
tickets.user.tenant => Param_0.UserNavigation.Tenant
tickets.user.name => Param_0.UserNavigation.Name
tickets.user.tickets => Param_0.UserNavigation.Tickets
tickets.customer_name => Param_0.CustomerName
tickets.tenant_name => Param_0.TenantName
tickets.user_name => Param_0.UserName
```

</details>

## How to test?

Same as in #439, with manual `curl` queries, or using the `integration-tests` docker compose target.