### PR TITLE
server/node: use /exp/compile API with UCAST target

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -75,6 +75,13 @@ jobs:
           fetch-depth: 0
       - name: setup
         run: docker compose --profile ${{ matrix.server }} --profile react up --quiet-pull --wait --wait-timeout 300
+        env:
+          OPA_DOCKERFILE: enterprise-opa.Dockerfile
+          EOPA_LICENSE_KEY: ${{ secrets.EOPA_LICENSE_KEY }}
+        if: matrix.server == 'node'
+      - name: setup
+        run: docker compose --profile ${{ matrix.server }} --profile react up --quiet-pull --wait --wait-timeout 300
+        if: matrix.server != 'node'
       - name: Install dependencies
         run: npm ci
         working-directory: tests/e2e

--- a/policies/filters.rego
+++ b/policies/filters.rego
@@ -1,0 +1,28 @@
+package tickets.filters
+
+tenancy if input.tickets.tenant == input.tenant.id # tenancy check
+
+include if {
+	tenancy
+	resolver_include
+}
+
+include if {
+	tenancy
+	not data.tickets.user_is_resolver(input.user, input.tenant.name)
+}
+
+resolver_include if {
+	data.tickets.user_is_resolver(input.user, input.tenant.name)
+
+	# ticket is assigned to user
+	input.users.name == input.user
+}
+
+resolver_include if {
+	data.tickets.user_is_resolver(input.user, input.tenant.name)
+
+	# ticket is unassigned and unresolved
+	input.tickets.assignee == null
+	input.tickets.resolved == false
+}

--- a/server/node/src/api.js
+++ b/server/node/src/api.js
@@ -170,14 +170,19 @@ router.post("/tickets", async (req, res) => {
 
 // list all tickets
 router.get("/tickets", async (req, res) => {
-  const { allow, reason, conditions } = await authz.authorized(
+  const { allow, reason } = await authz.authorized(
     path,
     { action: "list" },
     req,
   );
   if (!allow) return res.status(FORBIDDEN).json({ reason });
 
-  const filters = ucastToPrisma(conditions, "tickets");
+  const query = "data.tickets.filters.include";
+  const { result } = await authz
+    .conditions(query, { action: "list" }, req)
+    .then((res) => res.json());
+
+  const filters = ucastToPrisma(result, "tickets");
   const tickets = (
     await prisma.tickets.findMany({
       where: filters,

--- a/server/node/src/authz.js
+++ b/server/node/src/authz.js
@@ -9,6 +9,7 @@ export class UnauthorizedError extends Error {
 
 export class Authorizer {
   constructor(endpoint) {
+    this.endpoint = endpoint;
     this.opa = new OPAClient(endpoint);
   }
 
@@ -23,5 +24,36 @@ export class Authorizer {
     },
   ) {
     return this.opa.evaluate(path, { user, tenant, ...input });
+  }
+
+  // TODO(sr): this should be made simpler by the @styra/opa SDK!
+  async conditions(
+    query,
+    inp,
+    {
+      auth: {
+        tenant, // feed complete tenant info into OPA
+        subject: user,
+      },
+    },
+  ) {
+    const input = { user, tenant, ...inp };
+    const body = JSON.stringify({
+      query,
+      input,
+      unknowns: ["input.tickets", "input.users"],
+      options: {
+        dialect: "prisma",
+      },
+    });
+    const req = new Request(`${this.endpoint}/exp/compile`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/vnd.styra.ucast+json",
+      },
+      body,
+    });
+    return fetch(req);
   }
 }


### PR DESCRIPTION
This PR makes server/node no longer use the manual conditions construction approach, but use the (experimental!) /exp/compile API instead.

👉 [These are the filter rules.](https://github.com/StyraInc/styra-demo-tickethub/pull/524/files#diff-df04551bdddbe4af2cfc0c70263cea57135d995a37eb2ecab3f9368082531be5)