### PR TITLE
server/csharp: Change to support nested-object masking style.

### DIFF
--- a/policies/filters.rego
+++ b/policies/filters.rego
@@ -41,9 +41,9 @@ default masks.tickets.description := {"replace": {"value": "***"}}
 
 # Allow viewing the field if user is an admin or a resolver.
 masks.tickets.description := {} if {
-	"admin" in data.roles[input.tenant][input.user]
+	"admin" in data.roles[input.tenant.name][input.user]
 }
 
 masks.tickets.description := {} if {
-	"resolver" in data.roles[input.tenant][input.user]
+	"resolver" in data.roles[input.tenant.name][input.user]
 }

--- a/policies/filters.rego
+++ b/policies/filters.rego
@@ -10,7 +10,7 @@ tenancy if input.tickets.tenant == input.tenant.id # tenancy check
 #     - input.users
 #     - input.customers
 #     - input.tenants
-
+#   mask_rule: masks
 include if {
 	tenancy
 	resolver_include
@@ -37,13 +37,13 @@ resolver_include if {
 }
 
 # Default-deny mask.
-default masks["tickets.description"] := {"replace": {"value": "***"}}
+default masks.tickets.description := {"replace": {"value": "***"}}
 
 # Allow viewing the field if user is an admin or a resolver.
-masks["tickets.description"] := {} if {
+masks.tickets.description := {} if {
 	"admin" in data.roles[input.tenant][input.user]
 }
 
-masks["tickets.description"] := {} if {
+masks.tickets.description := {} if {
 	"resolver" in data.roles[input.tenant][input.user]
 }

--- a/server/csharp/TicketHub/TicketHub.csproj
+++ b/server/csharp/TicketHub/TicketHub.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="9.0.4" />
     <PackageReference Include="Npgsql.Json.NET" Version="9.0.3" />
     <PackageReference Include="Styra.Opa" Version="1.5.1" />
-    <PackageReference Include="Styra.Ucast.Linq" Version="0.3.1" />
+    <PackageReference Include="Styra.Ucast.Linq" Version="0.4.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## What changed?

This PR wraps up changes in the C# server to support using the combined data filters and column masks from the extended Compile API in Enterprise OPA.

Things that needed updating:
 - Pulling in the upstream ucast-linq changes (`0.4.0` supports the nested dictionary lookups we need)
 - Extracting both conditions and masks from the `/v1/compile/{path}` API call.
 - Reworking the filtering policy to use the modern mask rule style

Next steps after this PR:
 - Update the `OpaClient` APIs over in opa-csharp, to allow removing the custom `GetConditions` "shim" call here.