### PR TITLE
.github: Add default PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+### :nut_and_bolt: What code changed, and why?
+
+### :+1: Definition of done
+
+### :athletic_shoe: How to test
+
+### :chains: Related Resources
+


### PR DESCRIPTION
## What changed?

This PR adds a basic template for future PRs. It's based on a PR format originally created by @msorens, which we've used on other projects with some success.

Below the line is a sample of what will show up in future PRs:

-----

### :nut_and_bolt: What code changed, and why?

### :+1: Definition of done

### :athletic_shoe: How to test

### :chains: Related Resources