### PR TITLE
server/csharp: Breaking updates for the 1.5.x Styra.Opa package.

### DIFF
--- a/server/csharp/TicketHub/Authorization/OpaAuthorizationAttribute.cs
+++ b/server/csharp/TicketHub/Authorization/OpaAuthorizationAttribute.cs
@@ -45,7 +45,7 @@ public class OpaRuleAuthorizationAttribute : Attribute, IAsyncAuthorizationFilte
         var authzService = context.HttpContext.RequestServices.GetRequiredService<OpaAuthzService>();
         OpaClient opa = authzService.GetClient();
 
-        bool allowed = await opa.evaluate<bool>(_path, new Dictionary<string, object>(){
+        bool allowed = await opa.Evaluate<bool>(_path, new Dictionary<string, object>(){
             { "tenant", tenant },
             { "user", subject },
             { "action", _action },
@@ -95,7 +95,7 @@ public class OpaRuleActionFilterAttribute : ActionFilterAttribute
         var authzService = context.HttpContext.RequestServices.GetRequiredService<OpaAuthzService>();
         OpaClient opa = authzService.GetClient();
 
-        bool allowed = await opa.evaluate<bool>(_path, new Dictionary<string, object>(){
+        bool allowed = await opa.Evaluate<bool>(_path, new Dictionary<string, object>(){
             { "tenant", tenant },
             { "user", subject },
             { "action", _action },

--- a/server/csharp/TicketHub/Controllers/TicketController.cs
+++ b/server/csharp/TicketHub/Controllers/TicketController.cs
@@ -4,8 +4,6 @@ using System.Net.Mime;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
-using Styra.Opa;
-using Styra.Opa.OpenApi.Models.Components;
 using Styra.Ucast.Linq;
 using TicketHub.Authorization;
 using TicketHub.Database;

--- a/server/csharp/TicketHub/TicketHub.csproj
+++ b/server/csharp/TicketHub/TicketHub.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="9.0.4" />
     <PackageReference Include="Npgsql.Json.NET" Version="9.0.3" />
-    <PackageReference Include="Styra.Opa" Version="1.5.3" />
+    <PackageReference Include="Styra.Opa" Version="1.5.4" />
     <PackageReference Include="Styra.Ucast.Linq" Version="0.6.0" />
   </ItemGroup>
 


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

Recent breakging updates in the `Styra.Opa` package mean that we have to manually refactor some of our function/method calls over here in the server implementation.

### :+1: Definition of done

 - Do the build and unit test jobs run without error now?

### :athletic_shoe: How to test

### :chains: Related Resources

